### PR TITLE
add dependencies.console 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,7 @@ dirs = "^3.0.2"
 semver = "^1.0.0"
 toml = "^0.5.8"
 solana-transaction-status = "^1.7.3"
+
+[dependencies.console]
+version = "0.16.0"
+features = ["std"]


### PR DESCRIPTION
workaround to fix local build in newer os'es:

```
TASK [solana_exporter : build and install new solana-exporter] ******************************************************************************************************************************************************
Monday 18 August 2025  18:26:54 -0300 (0:00:00.933)       0:00:16.996 *********
fatal: [ams72]: FAILED! => {
    "changed": true,
    "cmd": [
        "/home/solana-exporter/.cargo/bin/cargo",
        "install",
        "--git",
        "https://github.com/rpcpool/solana-exporter.git"
    ],
    "delta": "0:01:12.154411",
    "end": "2025-08-18 21:28:06.800250",
    "rc": 101,
    "start": "2025-08-18 21:26:54.645839"
}

STDERR:

    Updating git repository `https://github.com/rpcpool/solana-exporter.git`
  Installing solana-exporter v0.4.1 (https://github.com/rpcpool/solana-exporter.git#df54c5ac)
    Updating crates.io index
     Locking 458 packages to latest compatible versions
      Adding bincode v1.3.3 (available: v2.0.1)
      Adding clap v2.34.0 (available: v4.5.45)
      Adding dirs v3.0.2 (available: v6.0.0)
      Adding env_logger v0.8.4 (available: v0.11.8)
      Adding reqwest v0.11.27 (available: v0.12.23)
      Adding solana-account-decoder v1.9.20 (available: v1.18.26)
      Adding solana-address-lookup-table-program v1.9.20 (available: v1.18.26)
      Adding solana-bloom v1.9.20 (available: v1.18.26)
      Adding solana-bucket-map v1.9.20 (available: v1.18.26)
      Adding solana-clap-utils v1.9.20 (available: v1.18.26)
      Adding solana-cli-config v1.9.20 (available: v1.18.26)
      Adding solana-client v1.9.20 (available: v1.18.26)
      Adding solana-compute-budget-program v1.9.20 (available: v1.18.26)
      Adding solana-config-program v1.9.20 (available: v1.18.26)
      Adding solana-faucet v1.9.20 (available: v1.18.26)
      Adding solana-frozen-abi v1.9.20 (available: v1.18.26)
      Adding solana-frozen-abi-macro v1.9.20 (available: v1.18.26)
      Adding solana-logger v1.9.20 (available: v1.18.26)
      Adding solana-measure v1.9.20 (available: v1.18.26)
      Adding solana-metrics v1.9.20 (available: v1.18.26)
      Adding solana-net-utils v1.9.20 (available: v1.18.26)
      Adding solana-perf v1.9.20 (available: v1.18.26)
      Adding solana-program v1.9.20 (available: v1.18.26)
      Adding solana-program-runtime v1.9.20 (available: v1.18.26)
      Adding solana-rayon-threadlimit v1.9.20 (available: v1.18.26)
      Adding solana-remote-wallet v1.9.20 (available: v1.18.26)
      Adding solana-runtime v1.9.20 (available: v1.18.26)
      Adding solana-sdk v1.9.20 (available: v1.18.26)
      Adding solana-sdk-macro v1.9.20 (available: v1.18.26)
      Adding solana-stake-program v1.9.20 (available: v1.18.26)
      Adding solana-transaction-status v1.9.20 (available: v1.18.26)
      Adding solana-version v1.9.20 (available: v1.18.26)
      Adding solana-vote-program v1.9.20 (available: v1.18.26)
      Adding spl-associated-token-account v1.0.3 (available: v1.1.3)
      Adding spl-token v3.2.0 (available: v3.5.0)
      Adding subtle v2.4.1 (available: v2.6.1)
      Adding time v0.2.27 (available: v0.3.41)
      Adding toml v0.5.11 (available: v0.9.5)
      Adding zeroize v1.3.0 (available: v1.8.1)
      Adding zstd-safe v4.1.3+zstd.1.5.1 (available: v4.1.6+zstd.1.5.2)
      Adding zstd-sys v1.6.2+zstd.1.5.1 (available: v1.6.3+zstd.1.5.2)
   Compiling proc-macro2 v1.0.101
   Compiling unicode-ident v1.0.18
   Compiling libc v0.2.175
   Compiling cfg-if v1.0.1
   Compiling version_check v0.9.5
   Compiling serde v1.0.219
   Compiling shlex v1.3.0
   Compiling typenum v1.18.0
   Compiling autocfg v1.5.0
   Compiling semver v1.0.26
   Compiling memchr v2.7.5
   Compiling generic-array v0.14.7
   Compiling syn v1.0.109
   Compiling once_cell v1.21.3
   Compiling subtle v2.4.1
   Compiling rustc_version v0.4.1
   Compiling log v0.4.27
   Compiling zerocopy v0.8.26
   Compiling quote v1.0.40
   Compiling lazy_static v1.5.0
   Compiling crunchy v0.2.4
   Compiling getrandom v0.1.16
   Compiling itoa v1.0.15
   Compiling syn v2.0.106
   Compiling block-padding v0.2.1
   Compiling smallvec v1.15.1
   Compiling opaque-debug v0.3.1
   Compiling aho-corasick v1.1.3
   Compiling regex-syntax v0.8.5
   Compiling jobserver v0.1.33
   Compiling getrandom v0.2.16
   Compiling cc v1.2.33
   Compiling thiserror v1.0.69
   Compiling cpufeatures v0.2.17
   Compiling rand_core v0.5.1
   Compiling fnv v1.0.7
   Compiling byteorder v1.5.0
   Compiling wasm-bindgen-shared v0.2.100
   Compiling atty v0.2.14
   Compiling ppv-lite86 v0.2.21
   Compiling stable_deref_trait v1.2.0
   Compiling percent-encoding v2.3.1
   Compiling rand_chacha v0.2.2
   Compiling regex-automata v0.4.9
   Compiling ahash v0.7.8
   Compiling rand v0.7.3
   Compiling rustversion v1.0.22
   Compiling bumpalo v3.19.0
   Compiling termcolor v1.4.1
   Compiling feature-probe v0.1.1
   Compiling humantime v2.2.0
   Compiling synstructure v0.13.2
   Compiling wasm-bindgen-backend v0.2.100
   Compiling bv v0.11.1
   Compiling solana-frozen-abi-macro v1.9.20
   Compiling num-traits v0.2.19
   Compiling lock_api v0.4.13
   Compiling pkg-config v0.3.32
   Compiling either v1.15.0
   Compiling regex v1.11.1
   Compiling wasm-bindgen-macro-support v0.2.100
   Compiling serde_derive v1.0.219
   Compiling thiserror-impl v1.0.69
   Compiling zeroize_derive v1.4.2
   Compiling zerofrom-derive v0.1.6
   Compiling zeroize v1.3.0
   Compiling yoke-derive v0.8.0
   Compiling zerovec-derive v0.11.1
   Compiling env_logger v0.9.3
   Compiling zerofrom v0.1.6
   Compiling yoke v0.8.0
   Compiling borsh-schema-derive-internal v0.9.3
   Compiling borsh-derive-internal v0.9.3
   Compiling blake3 v1.8.2
   Compiling solana-frozen-abi v1.9.20
   Compiling arrayref v0.3.9
   Compiling bitflags v1.3.2
   Compiling scopeguard v1.2.0
   Compiling object v0.36.7
   Compiling wasm-bindgen v0.2.100
   Compiling ryu v1.0.20
   Compiling adler2 v2.0.1
   Compiling miniz_oxide v0.8.9
   Compiling zerovec v0.11.4
   Compiling hashbrown v0.11.2
   Compiling solana-logger v1.9.20
   Compiling wasm-bindgen-macro v0.2.100
   Compiling displaydoc v0.2.5
   Compiling bytemuck_derive v1.10.1
   Compiling memmap2 v0.5.10
   Compiling solana-program v1.9.20
   Compiling base64 v0.13.1
   Compiling bs58 v0.4.0
   Compiling failure_derive v0.1.8
   Compiling pin-project-lite v0.2.16
   Compiling unicode-xid v0.2.6
   Compiling base64 v0.12.3
   Compiling keccak v0.1.5
   Compiling constant_time_eq v0.3.1
   Compiling arrayvec v0.7.6
   Compiling gimli v0.31.1
   Compiling synstructure v0.12.6
   Compiling solana-sdk-macro v1.9.20
   Compiling bytemuck v1.23.2
   Compiling num-derive v0.3.3
   Compiling itertools v0.10.5
   Compiling toml v0.5.11
   Compiling digest v0.9.0
   Compiling block-buffer v0.9.0
   Compiling sha2 v0.9.9
   Compiling crypto-mac v0.8.0
   Compiling libsecp256k1-core v0.2.2
   Compiling hmac v0.8.1
   Compiling curve25519-dalek v3.2.1
   Compiling block-buffer v0.10.4
   Compiling crypto-common v0.1.6
   Compiling proc-macro-crate v0.1.5
   Compiling libsecp256k1-gen-ecmult v0.2.1
   Compiling libsecp256k1-gen-genmult v0.2.1
   Compiling digest v0.10.7
   Compiling borsh-derive v0.9.3
   Compiling libsecp256k1 v0.6.0
   Compiling hmac-drbg v0.3.0
   Compiling borsh v0.9.3
   Compiling addr2line v0.24.2
   Compiling sha3 v0.9.1
   Compiling serde_bytes v0.11.17
   Compiling bincode v1.3.3
   Compiling rustc-demangle v0.1.26
   Compiling parking_lot_core v0.9.11
   Compiling serde_json v1.0.142
   Compiling backtrace v0.3.75
   Compiling signature v1.6.4
   Compiling ed25519 v1.5.3
   Compiling crypto-mac v0.11.1
   Compiling crypto-mac v0.9.1
   Compiling tinystr v0.8.1
   Compiling ring v0.17.14
   Compiling writeable v0.6.1
   Compiling failure v0.1.8
   Compiling litemap v0.8.0
   Compiling bytes v1.10.1
   Compiling icu_locale_core v2.0.0
   Compiling derivation-path v0.1.3
   Compiling hmac v0.9.0
   Compiling parking_lot v0.12.4
   Compiling ed25519-dalek v1.0.1
   Compiling zerotrie v0.2.2
   Compiling potential_utf v0.1.2
   Compiling solana-sdk v1.9.20
   Compiling iana-time-zone v0.1.63
   Compiling bitflags v2.9.2
   Compiling icu_properties_data v2.0.1
   Compiling icu_normalizer_data v2.0.0
   Compiling chrono v0.4.41
   Compiling icu_collections v2.0.0
   Compiling icu_provider v2.0.0
   Compiling ed25519-dalek-bip32 v0.1.1
   Compiling pbkdf2 v0.9.0
   Compiling hmac v0.11.0
   Compiling qstring v0.7.2
   Compiling uriparse v0.6.4
   Compiling futures-core v0.3.31
   Compiling futures-sink v0.3.31
   Compiling untrusted v0.9.0
   Compiling assert_matches v1.5.0
   Compiling tokio-macros v2.5.0
   Compiling socket2 v0.6.0
   Compiling mio v1.0.4
   Compiling signal-hook-registry v1.4.6
   Compiling vcpkg v0.2.15
   Compiling tokio v1.47.1
   Compiling icu_properties v2.0.1
   Compiling icu_normalizer v2.0.0
   Compiling openssl-sys v0.9.109
   Compiling futures-channel v0.3.31
   Compiling futures-macro v0.3.31
   Compiling futures-task v0.3.31
   Compiling pin-utils v0.1.0
   Compiling slab v0.4.11
   Compiling futures-io v0.3.31
   Compiling idna_adapter v1.2.1
   Compiling form_urlencoded v1.2.1
   Compiling utf8_iter v1.0.4
   Compiling idna v1.0.3
   Compiling http v0.2.12
   Compiling httparse v1.10.1
   Compiling crossbeam-utils v0.8.21
   Compiling futures-util v0.3.31
   Compiling url v2.5.4
   Compiling tracing-core v0.1.34
   Compiling openssl v0.10.73
   Compiling foreign-types-shared v0.1.1
   Compiling hashbrown v0.15.5
   Compiling equivalent v1.0.2
   Compiling foreign-types v0.3.2
   Compiling tracing v0.1.41
   Compiling indexmap v2.10.0
   Compiling tokio-util v0.7.16
   Compiling openssl-macros v0.1.1
   Compiling try-lock v0.2.5
   Compiling rustls v0.21.12
   Compiling native-tls v0.2.14
   Compiling want v0.3.1
   Compiling h2 v0.3.27
   Compiling http-body v0.4.6
   Compiling socket2 v0.5.10
   Compiling solana-program-runtime v1.9.20
   Compiling openssl-probe v0.1.6
   Compiling tower-service v0.3.3
   Compiling httpdate v1.0.3
   Compiling crossbeam-epoch v0.9.18
   Compiling libloading v0.7.4
   Compiling rustix v1.0.8
   Compiling linux-raw-sys v0.9.4
   Compiling rayon-core v1.13.0
   Compiling base64 v0.21.7
   Compiling crossbeam-deque v0.8.6
   Compiling serde_urlencoded v0.7.1
   Compiling rustls-pemfile v1.0.4
   Compiling encoding_rs v0.8.35
   Compiling getrandom v0.3.3
   Compiling sct v0.7.1
   Compiling rustls-webpki v0.101.7
   Compiling hyper v0.14.32
   Compiling tokio-native-tls v0.3.1
   Compiling ipnet v2.11.0
   Compiling tokio-rustls v0.24.1
   Compiling sync_wrapper v0.1.2
   Compiling mime v0.3.17
   Compiling webpki-roots v0.25.4
   Compiling zstd-sys v1.6.2+zstd.1.5.1
   Compiling gethostname v0.2.3
   Compiling solana-vote-program v1.9.20
   Compiling proc-macro2 v0.4.30
   Compiling hyper-rustls v0.24.2
   Compiling hyper-tls v0.5.0
   Compiling reqwest v0.11.27
   Compiling rayon v1.11.0
   Compiling fastrand v2.3.0
   Compiling unicode-xid v0.1.0
   Compiling winnow v0.5.40
   Compiling toml_datetime v0.6.11
   Compiling solana-measure v1.9.20
   Compiling solana-metrics v1.9.20
   Compiling toml_edit v0.19.15
   Compiling tempfile v3.20.0
   Compiling num_cpus v1.17.0
   Compiling solana-bloom v1.9.20
   Compiling memoffset v0.6.5
   Compiling proc-macro-error-attr v1.0.4
   Compiling zstd-safe v4.1.3+zstd.1.5.1
   Compiling syn v0.15.44
   Compiling parking_lot_core v0.8.6
   Compiling proc-macro-crate v1.3.1
   Compiling quote v0.6.13
   Compiling standback v0.2.17
   Compiling proc-macro-error v1.0.4
   Compiling instant v0.1.13
   Compiling crc32fast v1.5.0
   Compiling num_enum_derive v0.5.11
   Compiling solana-rayon-threadlimit v1.9.20
   Compiling hidapi v1.5.0
   Compiling bzip2-sys v0.1.13+1.0.8
   Compiling ring v0.16.20
   Compiling indexmap v1.9.3
   Compiling tinyvec_macros v0.1.1
   Compiling unicode-width v0.2.1
   Compiling unicode-width v0.1.14
   Compiling anyhow v1.0.99
   Compiling textwrap v0.11.0
   Compiling dlopen_derive v0.1.4
   Compiling console v0.15.11
   Compiling tinyvec v1.9.0
   Compiling Inflector v0.11.4
   Compiling num_enum v0.5.11
   Compiling nix v0.23.2
   Compiling parking_lot v0.11.2
   Compiling solana-config-program v1.9.20
   Compiling solana-version v1.9.20
   Compiling solana-stake-program v1.9.20
   Compiling solana-address-lookup-table-program v1.9.20
   Compiling solana-perf v1.9.20
   Compiling vec_map v0.8.2
   Compiling same-file v1.0.6
   Compiling strsim v0.8.0
   Compiling ansi_term v0.12.1
   Compiling yaml-rust v0.3.5
   Compiling hashbrown v0.12.3
   Compiling proc-macro-hack v0.5.20+deprecated
   Compiling linked-hash-map v0.5.6
   Compiling yaml-rust v0.4.5
   Compiling clap v2.34.0
   Compiling walkdir v2.5.0
   Compiling ouroboros_macro v0.13.0
   Compiling spl-token v3.2.0
   Compiling unicode-normalization v0.1.24
   Compiling dialoguer v0.9.0
   Compiling dlopen v0.1.8
   Compiling xattr v1.5.1
   Compiling webpki v0.22.4
   Compiling pbkdf2 v0.4.0
   Compiling caps v0.5.5
   Compiling rand_core v0.6.4
   Compiling dirs-sys-next v0.1.2
   Compiling filetime v0.2.25
   Compiling solana-runtime v1.9.20
   Compiling rustc-hash v1.1.0
   Compiling powerfmt v0.2.0
   Compiling fs_extra v1.3.0
   Compiling rustls v0.20.9
   Compiling time-core v0.1.4
   Compiling spin v0.5.2
   Compiling untrusted v0.7.1
   Compiling base32 v0.4.0
   Compiling aliasable v0.1.3
   Compiling num-conv v0.1.0
   Compiling ouroboros v0.13.0
   Compiling solana-remote-wallet v1.9.20
   Compiling time-macros v0.2.22
   Compiling solana-bucket-map v1.9.20
   Compiling deranged v0.4.0
   Compiling tiny-bip39 v0.8.2
   Compiling tar v0.4.44
   Compiling dirs-next v2.0.0
   Compiling rand_chacha v0.3.1
   Compiling bzip2 v0.4.4
   Compiling dir-diff v0.3.3
   Compiling serde_yaml v0.8.26
   Compiling flate2 v1.1.2
   Compiling dashmap v4.0.2
   Compiling solana-compute-budget-program v1.9.20
   Compiling spl-memo v3.0.1
   Compiling crossbeam-channel v0.5.15
   Compiling futures-executor v0.3.31
   Compiling rpassword v5.0.1
   Compiling prometheus v0.13.4
   Compiling index_list v0.2.16
   Compiling symlink v0.1.0
   Compiling const_fn v0.4.11
   Compiling solana-clap-utils v1.9.20
   Compiling time v0.3.41
   Compiling futures v0.3.31
   Compiling solana-cli-config v1.9.20
   Compiling time-macros-impl v0.1.2
   Compiling rand v0.8.5
   Compiling spl-associated-token-account v1.0.3
   Compiling webpki-roots v0.22.6
   Compiling sha-1 v0.9.8
   Compiling socket2 v0.4.10
   Compiling time v0.2.27
   Compiling ascii v1.1.0
   Compiling utf-8 v0.7.6
   Compiling number_prefix v0.4.0
   Compiling console v0.16.0
   Compiling chunked_transfer v1.5.0
   Compiling indicatif v0.16.2
error[E0432]: unresolved import `console::Term`
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/indicatif-0.16.2/src/state.rs:10:5
   |
10 | use console::Term;
   |     ^^^^^^^^^^^^^ no `Term` in the root
   |
note: found an item that was configured out
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/console-0.16.0/src/lib.rs:92:42
   |
92 |     user_attended, user_attended_stderr, Term, TermFamily, TermFeatures, TermTarget,
   |                                          ^^^^
note: the item is gated behind the `std` feature
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/console-0.16.0/src/lib.rs:90:7
   |
90 | #[cfg(feature = "std")]
   |       ^^^^^^^^^^^^^^^
help: consider importing this variant instead
   |
10 - use console::Term;
10 + use crate::state::ProgressDrawTargetKind::Term;
   |

error[E0432]: unresolved imports `console::measure_text_width`, `console::Style`
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/indicatif-0.16.2/src/style.rs:1:15
   |
1  | use console::{measure_text_width, Style};
   |               ^^^^^^^^^^^^^^^^^^  ^^^^^ no `Style` in the root
   |               |
   |               no `measure_text_width` in the root
   |
note: found an item that was configured out
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/console-0.16.0/src/lib.rs:96:44
   |
96 |     colors_enabled, colors_enabled_stderr, measure_text_width, pad_str, pad_str_with,
   |                                            ^^^^^^^^^^^^^^^^^^
note: the item is gated behind the `std` feature
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/console-0.16.0/src/lib.rs:94:7
   |
94 | #[cfg(feature = "std")]
   |       ^^^^^^^^^^^^^^^
note: found an item that was configured out
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/console-0.16.0/src/lib.rs:98:19
   |
98 |     Color, Emoji, Style, StyledObject,
   |                   ^^^^^
note: the item is gated behind the `std` feature
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/console-0.16.0/src/lib.rs:94:7
   |
94 | #[cfg(feature = "std")]
   |       ^^^^^^^^^^^^^^^

error[E0432]: unresolved imports `console::measure_text_width`, `console::Style`
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/indicatif-0.16.2/src/utils.rs:7:15
   |
7  | use console::{measure_text_width, Style};
   |               ^^^^^^^^^^^^^^^^^^  ^^^^^ no `Style` in the root
   |               |
   |               no `measure_text_width` in the root
   |
note: found an item that was configured out
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/console-0.16.0/src/lib.rs:96:44
   |
96 |     colors_enabled, colors_enabled_stderr, measure_text_width, pad_str, pad_str_with,
   |                                            ^^^^^^^^^^^^^^^^^^
note: the item is gated behind the `std` feature
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/console-0.16.0/src/lib.rs:94:7
   |
94 | #[cfg(feature = "std")]
   |       ^^^^^^^^^^^^^^^
note: found an item that was configured out
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/console-0.16.0/src/lib.rs:98:19
   |
98 |     Color, Emoji, Style, StyledObject,
   |                   ^^^^^
note: the item is gated behind the `std` feature
  --> /home/solana-exporter/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/console-0.16.0/src/lib.rs:94:7
   |
94 | #[cfg(feature = "std")]
   |       ^^^^^^^^^^^^^^^

   Compiling tiny_http v0.10.0
For more information about this error, try `rustc --explain E0432`.
error: could not compile `indicatif` (lib) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to compile `solana-exporter v0.4.1 (https://github.com/rpcpool/solana-exporter.git#df54c5ac)`, intermediate artifacts can be found at `/tmp/cargo-installElV3cr`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.


MSG:

non-zero return code
```