### PR TITLE
ci: migrate to goreleaser Gen 2 (PLA-456)

### DIFF
--- a/.github/workflows/goreleaser-config-check.yaml
+++ b/.github/workflows/goreleaser-config-check.yaml
@@ -1,0 +1,26 @@
+---
+name: GoReleaser config check
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - .goreleaser.yaml
+  workflow_dispatch:
+
+jobs:
+  goreleaser-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          install-only: true
+
+      - name: goreleaser check
+        run: goreleaser check

--- a/.github/workflows/goreleaser-config-check.yaml
+++ b/.github/workflows/goreleaser-config-check.yaml
@@ -14,11 +14,11 @@ jobs:
   goreleaser-check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 1
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c
         with:
           install-only: true
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
+builds:
+  - id: solana-exporter
+    builder: rust
+    binary: solana-exporter
+    targets:
+      - x86_64-unknown-linux-gnu
+    flags:
+      - --release
+      - --locked
+
+archives:
+  - id: solana-exporter
+    name_template: solana-exporter-linux-amd64
+    formats: [binary]
+    ids:
+      - solana-exporter
+
+release:
+  disable: "{{ .Prerelease }}"
+  header: |
+    rust {{ .Env.RUST_VERSION }}
+
+changelog:
+  sort: asc
+  use: github


### PR DESCRIPTION
Migrates to goreleaser-based CI workflow.

Installs .goreleaser.yaml and goreleaser-config-check workflow.
Drops ubuntu-24.04 build matrix (ubuntu-22.04 only).
Build and release triggered via workflow_dispatch on Binaries-ci.