### PR TITLE
Fix -32601 against Alpenglow by bypassing the version-based method remap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.28",
+ "proc-macro2 1.0.106",
  "syn 1.0.74",
 ]
 
@@ -246,8 +246,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2102f62f8b6d3edeab871830782285b64cc1830168094db05c8e458f209bc5c3"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
 ]
 
@@ -257,8 +257,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "196c978c4c9b0b142d446ef3240690bf5a8a33497074a113ff9a337ccb750483"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
 ]
 
@@ -686,8 +686,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
 ]
 
@@ -876,8 +876,8 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
  "synstructure",
 ]
@@ -1037,8 +1037,8 @@ checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
 ]
 
@@ -1266,7 +1266,7 @@ checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
- "itoa",
+ "itoa 0.4.7",
 ]
 
 [[package]]
@@ -1313,7 +1313,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.7",
  "pin-project-lite",
  "socket2 0.4.1",
  "tokio 1.9.0",
@@ -1377,7 +1377,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
- "console 0.14.1",
+ "console 0.16.3",
  "lazy_static",
  "number_prefix",
  "regex",
@@ -1430,6 +1430,12 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -1767,8 +1773,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
 ]
 
@@ -1818,8 +1824,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1def5a3f69d4707d8a040b12785b98029a39e8c610ae685c7f6265669767482"
 dependencies = [
  "proc-macro-crate 1.0.0",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
 ]
 
@@ -1911,8 +1917,8 @@ checksum = "f463857a6eb96c0136b1d56e56c718350cef30412ec065b48294799a088bca68"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
 ]
 
@@ -2074,8 +2080,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
  "version_check",
 ]
@@ -2086,8 +2092,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "version_check",
 ]
 
@@ -2114,11 +2120,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
- "unicode-xid 0.2.2",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2169,11 +2175,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
- "proc-macro2 1.0.28",
+ "proc-macro2 1.0.106",
 ]
 
 [[package]]
@@ -2542,10 +2548,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -2559,25 +2566,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.127"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "itoa",
- "ryu",
+ "itoa 1.0.18",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2587,7 +2605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde",
 ]
@@ -2866,6 +2884,7 @@ dependencies = [
  "reqwest",
  "semver 1.0.4",
  "serde",
+ "serde_json",
  "sled",
  "solana-client",
  "solana-runtime",
@@ -2926,8 +2945,8 @@ version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fefced09f5cf4a8bb6b3d475a08992f28215c1bc5c05a2657a85c0e80e8cfd"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "rustc_version",
  "syn 1.0.74",
 ]
@@ -3163,8 +3182,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e988d7938720ca3090cc02caafa7952a98e28d153c5ecc7661208d5adfd520"
 dependencies = [
  "bs58",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "rustversion",
  "syn 1.0.74",
 ]
@@ -3335,8 +3354,8 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "serde",
  "serde_derive",
  "syn 1.0.74",
@@ -3349,8 +3368,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3399,9 +3418,20 @@ version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "unicode-xid 0.2.2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3410,8 +3440,8 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
  "unicode-xid 0.2.2",
 ]
@@ -3493,8 +3523,8 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
 ]
 
@@ -3541,8 +3571,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "standback",
  "syn 1.0.74",
 ]
@@ -3696,8 +3726,8 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
 ]
 
@@ -3924,6 +3954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4062,8 +4098,8 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
  "wasm-bindgen-shared",
 ]
@@ -4086,7 +4122,7 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
- "quote 1.0.9",
+ "quote 1.0.45",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4096,8 +4132,8 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -4254,11 +4290,17 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
  "syn 1.0.74",
  "synstructure",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ dirs = "^3.0.2"
 semver = "^1.0.0"
 toml = "^0.5.8"
 solana-transaction-status = "^1.7.3"
+serde_json = "1.0.150"
 
 [dependencies.console]
 version = "0.16.0"

--- a/src/gauges.rs
+++ b/src/gauges.rs
@@ -4,7 +4,7 @@ use crate::geolocation::api::MAXMIND_CITY_URI;
 use crate::geolocation::caching::GeolocationCache;
 use crate::geolocation::get_rpc_contact_ip;
 use crate::geolocation::identifier::DatacenterIdentifier;
-use crate::rpc_extra::with_first_block;
+use crate::rpc_extra::{get_block_with_config, with_first_block};
 use anyhow::{anyhow, Context};
 use futures::TryFutureExt;
 use geoip2_city::CityApiResponse;
@@ -307,8 +307,8 @@ impl PrometheusGauges {
 
         with_first_block(client, epoch_info.epoch, |block| {
             let average_slot_time = (OffsetDateTime::now_utc().unix_timestamp()
-                - client
-                    .get_block_with_config(
+                - get_block_with_config(
+                        client,
                         block,
                         RpcBlockConfig {
                             encoding: Some(UiTransactionEncoding::Base64),

--- a/src/gauges.rs
+++ b/src/gauges.rs
@@ -258,7 +258,6 @@ impl PrometheusGauges {
             .chain(vote_accounts.delinquent.iter())
             .filter(|rpc| self.vote_accounts_whitelist.contains(&rpc.vote_pubkey))
         {
-           
             self.activated_stake
                 .get_metric_with_label_values(&[&*v.vote_pubkey])
                 .map(|m| m.set(v.activated_stake as i64))?;
@@ -283,7 +282,6 @@ impl PrometheusGauges {
                     .get_metric_with_label_values(&[&*v.vote_pubkey, &*epoch.to_string()])
                     .map(|m| m.set(*current_epoch_credits as i64))?;
             }
- 
         }
 
         Ok(())
@@ -308,17 +306,17 @@ impl PrometheusGauges {
         with_first_block(client, epoch_info.epoch, |block| {
             let average_slot_time = (OffsetDateTime::now_utc().unix_timestamp()
                 - get_block_with_config(
-                        client,
-                        block,
-                        RpcBlockConfig {
-                            encoding: Some(UiTransactionEncoding::Base64),
-                            transaction_details: Some(TransactionDetails::None),
-                            rewards: Some(false),
-                            commitment: None,
-                        },
-                    )?
-                    .block_time
-                    .unwrap()) as f64
+                    client,
+                    block,
+                    RpcBlockConfig {
+                        encoding: Some(UiTransactionEncoding::Base64),
+                        transaction_details: Some(TransactionDetails::None),
+                        rewards: Some(false),
+                        commitment: None,
+                    },
+                )?
+                .block_time
+                .unwrap()) as f64
                 / (epoch_info.slot_index) as f64;
             self.average_slot_time.set(average_slot_time);
             Ok(Some(()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,8 +151,14 @@ and then put real values there.",
 
     let gauges = PrometheusGauges::new(vote_accounts_whitelist.clone());
     let mut skipped_slots_monitor = if enable_skipped_slots {
-        Some(SkippedSlotsMonitor::new(&client, &gauges.leader_slots, &gauges.skipped_slot_percent))
-    } else { None };
+        Some(SkippedSlotsMonitor::new(
+            &client,
+            &gauges.leader_slots,
+            &gauges.skipped_slot_percent,
+        ))
+    } else {
+        None
+    };
 
     let rewards_monitor = if enable_rewards {
         Some(RewardsMonitor::new(
@@ -163,7 +169,10 @@ and then put real values there.",
             &rewards_cache,
             &staking_account_whitelist,
             &vote_accounts_whitelist,
-        ) ) } else { None };
+        ))
+    } else {
+        None
+    };
 
     loop {
         let _guard = exporter.wait_duration(duration);
@@ -197,13 +206,16 @@ and then put real values there.",
         }
 
         if enable_skipped_slots {
-            skipped_slots_monitor.as_mut().unwrap().export_skipped_slots(&epoch_info, &node_whitelist)
-              .context("Failed to export skipped slots")?;
+            skipped_slots_monitor
+                .as_mut()
+                .unwrap()
+                .export_skipped_slots(&epoch_info, &node_whitelist)
+                .context("Failed to export skipped slots")?;
         }
 
         if let Some(x) = &rewards_monitor {
             x.export_rewards(&epoch_info)
                 .context("Failed to export rewards")?;
-        } 
+        }
     }
 }

--- a/src/rewards/mod.rs
+++ b/src/rewards/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::Whitelist;
 use crate::rewards::caching::{PubkeyVoterApyMapping, RewardsCache};
-use crate::rpc_extra::with_first_block;
+use crate::rpc_extra::{get_block, get_block_with_config, with_first_block};
 use anyhow::anyhow;
 use log::debug;
 use prometheus_exporter::prometheus::{GaugeVec, IntGaugeVec};
@@ -375,7 +375,7 @@ impl<'a> RewardsMonitor<'a> {
         // If it's the current epoch then we must extrapolate
         if epoch == epoch_info.epoch {
             let first_slot = epoch_info.absolute_slot - epoch_info.slot_index;
-            return if let Some(first_slot_time) = self.client.get_block(first_slot)?.block_time {
+            return if let Some(first_slot_time) = get_block(self.client, first_slot)?.block_time {
                 let average_slot_time = (OffsetDateTime::now_utc().unix_timestamp()
                     - first_slot_time) as f64
                     / (epoch_info.slot_index) as f64;
@@ -394,7 +394,8 @@ impl<'a> RewardsMonitor<'a> {
             let days_in_epoch = {
                 let first_block_timestamp = |ep| {
                     with_first_block(self.client, ep, |block| {
-                        let ui_confirmed_block = self.client.get_block_with_config(
+                        let ui_confirmed_block = get_block_with_config(
+                            self.client,
                             block,
                             RpcBlockConfig {
                                 encoding: Some(UiTransactionEncoding::Base64),
@@ -434,7 +435,7 @@ impl<'a> RewardsMonitor<'a> {
             Ok(Some(rewards))
         } else {
             with_first_block(self.client, epoch, |block| {
-                let rewards = self.client.get_block(block)?.rewards;
+                let rewards = get_block(self.client, block)?.rewards;
                 self.cache.add_epoch_rewards(epoch, &rewards)?;
                 Ok(Some(rewards))
             })

--- a/src/rpc_extra.rs
+++ b/src/rpc_extra.rs
@@ -59,7 +59,9 @@ where
     let first_slot = epoch_schedule.get_first_slot_in_epoch(epoch);
 
     // First block in `epoch`.
-    let first_block = get_blocks_with_limit(client, first_slot, 1)?.get(0).cloned();
+    let first_block = get_blocks_with_limit(client, first_slot, 1)?
+        .get(0)
+        .cloned();
 
     if let Some(block) = first_block {
         f(block)

--- a/src/rpc_extra.rs
+++ b/src/rpc_extra.rs
@@ -1,6 +1,54 @@
 use crate::config::Whitelist;
-use solana_client::{rpc_client::RpcClient, rpc_response::RpcVoteAccountStatus};
-use solana_sdk::clock::Epoch;
+use serde_json::json;
+use solana_client::{
+    client_error::Result as ClientResult, rpc_client::RpcClient, rpc_config::RpcBlockConfig,
+    rpc_request::RpcRequest, rpc_response::RpcVoteAccountStatus,
+};
+use solana_sdk::clock::{Epoch, Slot};
+use solana_transaction_status::{EncodedConfirmedBlock, UiConfirmedBlock, UiTransactionEncoding};
+
+// The 1.7.x `RpcClient` routes the block methods through `maybe_map_request`,
+// which downgrades `getBlock`/`getBlocks`/`getBlocksWithLimit` to the removed
+// `getConfirmed*` names whenever the node reports a version < 1.7.0. Alpenglow
+// reports `solana-core` "0.4.1", so every such call becomes a -32601
+// "Method not found". These thin wrappers call `send` directly with the modern
+// request variant, bypassing the version remap. They mirror the upstream
+// 1.7.9 method bodies exactly (minus the `maybe_map_request` wrapper).
+
+/// `RpcClient::get_blocks_with_limit` without the version-based method remap.
+pub fn get_blocks_with_limit(
+    client: &RpcClient,
+    start_slot: Slot,
+    limit: usize,
+) -> ClientResult<Vec<Slot>> {
+    client.send(RpcRequest::GetBlocksWithLimit, json!([start_slot, limit]))
+}
+
+/// `RpcClient::get_blocks` without the version-based method remap.
+pub fn get_blocks(
+    client: &RpcClient,
+    start_slot: Slot,
+    end_slot: Option<Slot>,
+) -> ClientResult<Vec<Slot>> {
+    client.send(RpcRequest::GetBlocks, json!([start_slot, end_slot]))
+}
+
+/// `RpcClient::get_block` without the version-based method remap.
+pub fn get_block(client: &RpcClient, slot: Slot) -> ClientResult<EncodedConfirmedBlock> {
+    client.send(
+        RpcRequest::GetBlock,
+        json!([slot, UiTransactionEncoding::Json]),
+    )
+}
+
+/// `RpcClient::get_block_with_config` without the version-based method remap.
+pub fn get_block_with_config(
+    client: &RpcClient,
+    slot: Slot,
+    config: RpcBlockConfig,
+) -> ClientResult<UiConfirmedBlock> {
+    client.send(RpcRequest::GetBlock, json!([slot, config]))
+}
 
 /// Applies `f` to the first block in `epoch`.
 pub fn with_first_block<F, A>(client: &RpcClient, epoch: Epoch, f: F) -> anyhow::Result<Option<A>>
@@ -11,7 +59,7 @@ where
     let first_slot = epoch_schedule.get_first_slot_in_epoch(epoch);
 
     // First block in `epoch`.
-    let first_block = client.get_blocks_with_limit(first_slot, 1)?.get(0).cloned();
+    let first_block = get_blocks_with_limit(client, first_slot, 1)?.get(0).cloned();
 
     if let Some(block) = first_block {
         f(block)

--- a/src/slots.rs
+++ b/src/slots.rs
@@ -1,6 +1,7 @@
 //! Statistics of skipped and validated slots.
 
 use crate::config::Whitelist;
+use crate::rpc_extra::get_blocks;
 use log::{debug, log_enabled, Level};
 use prometheus_exporter::prometheus::{GaugeVec, IntCounterVec};
 use solana_client::{client_error::ClientError, rpc_client::RpcClient};
@@ -104,10 +105,11 @@ impl<'a> SkippedSlotsMonitor<'a> {
                 "Getting confirmed blocks from {} to {}",
                 abs_range_step, abs_range_step_end
             );
-            confirmed_blocks.extend(
-                self.client
-                    .get_blocks(abs_range_step, Some(abs_range_step_end))?,
-            );
+            confirmed_blocks.extend(get_blocks(
+                self.client,
+                abs_range_step,
+                Some(abs_range_step_end),
+            )?);
         }
         confirmed_blocks.sort_unstable();
         debug!(


### PR DESCRIPTION
## Problem

Running the exporter against an Alpenglow RPC endpoint fails with:

```
Error: Failed to export epoch info metrics
Caused by:
    0: RPC request error: ... {"code":-32601,"message":"Method not found"} ...
```

HTTP access logs show `200 OK` because JSON-RPC returns errors inside a 200 body.

## Root cause

`solana-client` 1.7.x runs block/signature/transaction calls through `maybe_map_request`, which downgrades `getBlock` / `getBlocks` / `getBlocksWithLimit` / `getSignaturesForAddress` / `getTransaction` to their removed `getConfirmed*` equivalents whenever the node's reported version parses `< 1.7.0`:

```rust
if self.get_node_version()? < semver::Version::new(1, 7, 0) {
    request = match request {
        RpcRequest::GetBlocksWithLimit => RpcRequest::GetConfirmedBlocksWithLimit,
        ...
    };
}
```

Alpenglow reports `getVersion → {"solana-core":"0.4.1"}`. Since `0.4.1 < 1.7.0`, the client sends the long-removed `getConfirmed*` names, which the node doesn't serve → `-32601`. The node actually serves every modern method (full RPC API is on); the bug is entirely client-side.

The first remapped call is `export_epoch_info → with_first_block → get_blocks_with_limit`, which is why "epoch info metrics" is the visible failure (`export_vote_accounts` runs first and isn't remapped, so it succeeds).

## Fix

Add thin wrappers in `src/rpc_extra.rs` that call `RpcClient::send` with the modern `RpcRequest` variant directly (mirroring the upstream 1.7.9 method bodies minus the `maybe_map_request` wrapper), and route all six call sites through them:

- `rpc_extra.rs` — `with_first_block`
- `gauges.rs` — `export_epoch_info`
- `slots.rs` — skipped-slots monitor
- `rewards/mod.rs` — epoch duration + rewards (3 sites)

`serde_json` is added as a direct dependency for the `json!` params (it was already transitive; this bumps it within 1.x, hence the `Cargo.lock` churn). No dependency major-version bump otherwise — keeps the working `solana-client 1.7.9` tree.

## Verification

Built clean and ran the binary against a live Alpenglow endpoint with skipped-slots enabled (exercises both the `get_block_with_config` and `get_blocks` paths). No errors; previously-broken metrics populate:

```
solana_average_slot_time 0.4248...
solana_current_epoch 11
solana_leader_slots{...,status="validated"} 392
solana_active_validators{status="current"} 80
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)