### PR TITLE
Tolerate non-string clientId in getClusterNodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3440,6 +3440,7 @@ dependencies = [
  "reqwest 0.11.4",
  "semver 1.0.28",
  "serde",
+ "serde_json",
  "sled",
  "solana-account",
  "solana-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ solana-epoch-info = "3.1.0"
 sled = "^0.34.6"
 bincode = "^1.3.3"
 serde = { version = "^1.0.126", features = ["derive"] }
+serde_json = "^1.0"
 # Use rustls instead of the default native-tls (OpenSSL) backend: the goreleaser
 # rust builder cross-compiles with cargo-zigbuild, and openssl-sys can't locate
 # the multiarch OpenSSL headers under zig's --target. rustls is pure Rust and

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ and then put real values there.",
 
         // Get metrics we need
         let epoch_info = client.get_epoch_info()?;
-        let nodes = client.get_cluster_nodes()?;
+        let nodes = rpc_extra::get_cluster_nodes_lenient(&client)?;
         let vote_accounts = client.get_vote_accounts()?;
         let node_whitelist = rpc_extra::node_pubkeys(&vote_accounts_whitelist, &vote_accounts);
 

--- a/src/rpc_extra.rs
+++ b/src/rpc_extra.rs
@@ -1,6 +1,38 @@
 use crate::config::Whitelist;
-use solana_client::{rpc_client::RpcClient, rpc_response::RpcVoteAccountStatus};
+use anyhow::Context;
+use serde_json::Value;
+use solana_client::{
+    rpc_client::RpcClient,
+    rpc_request::RpcRequest,
+    rpc_response::{RpcContactInfo, RpcVoteAccountStatus},
+};
 use solana_clock::Epoch;
+
+/// Fetches the cluster nodes, tolerating a non-conformant `clientId` field.
+///
+/// solana-client 4.0.0 added `RpcContactInfo.client_id: Option<String>` and
+/// parses it strictly as a string. Some networks (e.g. doublezero) return
+/// `clientId` as an integer, which makes `RpcClient::get_cluster_nodes` fail
+/// deserialization of the *entire* response. We fetch the raw JSON and coerce
+/// any non-string, non-null `clientId` to its string form before deserializing
+/// into the typed `RpcContactInfo`.
+pub fn get_cluster_nodes_lenient(client: &RpcClient) -> anyhow::Result<Vec<RpcContactInfo>> {
+    let mut raw: Value = client
+        .send(RpcRequest::GetClusterNodes, Value::Null)
+        .context("getClusterNodes RPC call failed")?;
+
+    if let Some(nodes) = raw.as_array_mut() {
+        for node in nodes {
+            if let Some(client_id) = node.get_mut("clientId") {
+                if !client_id.is_string() && !client_id.is_null() {
+                    *client_id = Value::String(client_id.to_string());
+                }
+            }
+        }
+    }
+
+    serde_json::from_value(raw).context("failed to deserialize getClusterNodes response")
+}
 
 /// Applies `f` to the first block in `epoch`.
 pub fn with_first_block<F, A>(client: &RpcClient, epoch: Epoch, f: F) -> anyhow::Result<Option<A>>


### PR DESCRIPTION
solana-client 4.0.0 added RpcContactInfo.client_id: Option<String> and parses it strictly as a string. Some networks (e.g. doublezero) return clientId as an integer, which fails deserialization of the entire getClusterNodes response and crash-loops the exporter for that network.

Fetch the raw JSON and coerce any non-string, non-null clientId to its string form before deserializing into the typed RpcContactInfo. Only the getClusterNodes call site changes; downstream code keeps using RpcContactInfo unchanged.