### PR TITLE
Replace skipped-slots getBlocks scan with getBlockProduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 target/
 *~
 geolocation_cache.db
+# Local configs (may contain tokened RPC URLs) and test artifacts
+config.toml
+test-config*.toml
+*.db/
+dist/
+solana-exporter-linux-amd64

--- a/src/gauges.rs
+++ b/src/gauges.rs
@@ -4,7 +4,7 @@ use crate::geolocation::api::MAXMIND_CITY_URI;
 use crate::geolocation::caching::GeolocationCache;
 use crate::geolocation::get_rpc_contact_ip;
 use crate::geolocation::identifier::DatacenterIdentifier;
-use crate::rpc_extra::with_first_block;
+use crate::rpc_extra::first_block_in_epoch;
 use anyhow::{anyhow, Context};
 use futures::TryFutureExt;
 use geoip2_city::CityApiResponse;
@@ -13,7 +13,7 @@ use prometheus_exporter::prometheus::{
     register_gauge, register_gauge_vec, register_int_counter_vec, register_int_gauge,
     register_int_gauge_vec, Gauge, GaugeVec, IntCounterVec, IntGauge, IntGaugeVec,
 };
-use solana_client::rpc_client::RpcClient;
+use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_config::RpcBlockConfig;
 use solana_client::rpc_response::{RpcContactInfo, RpcVoteAccountInfo, RpcVoteAccountStatus};
 use solana_epoch_info::EpochInfo;
@@ -288,7 +288,7 @@ impl PrometheusGauges {
     }
 
     /// Exports gauges for epoch
-    pub fn export_epoch_info(
+    pub async fn export_epoch_info(
         &self,
         epoch_info: &EpochInfo,
         client: &RpcClient,
@@ -303,7 +303,7 @@ impl PrometheusGauges {
         self.current_epoch_first_slot.set(first_slot as i64);
         self.current_epoch_last_slot.set(last_slot as i64);
 
-        with_first_block(client, epoch_info.epoch, |block| {
+        if let Some(block) = first_block_in_epoch(client, epoch_info.epoch).await? {
             let average_slot_time = (OffsetDateTime::now_utc().unix_timestamp()
                 - client
                     .get_block_with_config(
@@ -315,19 +315,19 @@ impl PrometheusGauges {
                             commitment: None,
                             max_supported_transaction_version: Some(0),
                         },
-                    )?
+                    )
+                    .await?
                     .block_time
                     .unwrap()) as f64
                 / (epoch_info.slot_index) as f64;
             self.average_slot_time.set(average_slot_time);
-            Ok(Some(()))
-        })?;
+        }
 
         Ok(())
     }
 
     /// Exports information about nodes
-    pub fn export_nodes_info(
+    pub async fn export_nodes_info(
         &self,
         nodes: &[RpcContactInfo],
         client: &RpcClient,
@@ -335,16 +335,18 @@ impl PrometheusGauges {
     ) -> anyhow::Result<()> {
         // Balance of node pubkeys. Only exported if a whitelist is set!
         if !node_whitelist.0.is_empty() {
-            let balances = nodes
-                .iter()
-                .filter(|rpc| node_whitelist.contains(&rpc.pubkey))
-                .map(|rpc| {
-                    Ok((
-                        rpc.pubkey.clone(),
-                        client.get_balance(&rpc.pubkey.parse()?)?,
-                    ))
-                })
-                .collect::<anyhow::Result<Vec<_>>>()?;
+            // Fetch the whitelisted node balances concurrently rather than
+            // issuing one blocking `getBalance` round-trip per node in series.
+            let balances = futures::future::try_join_all(
+                nodes
+                    .iter()
+                    .filter(|rpc| node_whitelist.contains(&rpc.pubkey))
+                    .map(|rpc| async move {
+                        let pubkey = rpc.pubkey.parse()?;
+                        anyhow::Ok((rpc.pubkey.clone(), client.get_balance(&pubkey).await?))
+                    }),
+            )
+            .await?;
 
             for (pubkey, balance) in balances {
                 self.node_pubkey_balances

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use crate::slots::SkippedSlotsMonitor;
 use anyhow::Context;
 use clap::{load_yaml, App};
 use log::{debug, warn};
-use solana_client::rpc_client::RpcClient;
+use solana_client::nonblocking::rpc_client::RpcClient;
 use std::fs::{create_dir_all, File};
 use std::io::Write;
 use std::net::SocketAddr;
@@ -134,7 +134,11 @@ and then put real values there.",
 
     let exporter = prometheus_exporter::start(config.target)?;
     let duration = Duration::from_secs(1);
-    let client = RpcClient::new(config.rpc.clone());
+    // Interim generous ceiling: a single timeout aborts the whole update cycle
+    // and exits the process, so until per-export error isolation lands, give
+    // slow calls (e.g. epoch-boundary `getBlock` on the rewards path) room to
+    // complete rather than triggering a cold restart.
+    let client = RpcClient::new_with_timeout(config.rpc.clone(), Duration::from_secs(120));
 
     let geolocation_cache =
         GeolocationCache::new(persistent_database.tree(GEO_DB_CACHE_TREE_NAME)?);
@@ -183,9 +187,9 @@ and then put real values there.",
         debug!("Updating metrics");
 
         // Get metrics we need
-        let epoch_info = client.get_epoch_info()?;
-        let nodes = rpc_extra::get_cluster_nodes_lenient(&client)?;
-        let vote_accounts = client.get_vote_accounts()?;
+        let epoch_info = client.get_epoch_info().await?;
+        let nodes = rpc_extra::get_cluster_nodes_lenient(&client).await?;
+        let vote_accounts = client.get_vote_accounts().await?;
         let node_whitelist = rpc_extra::node_pubkeys(&vote_accounts_whitelist, &vote_accounts);
 
         gauges
@@ -193,8 +197,11 @@ and then put real values there.",
             .context("Failed to export vote account metrics")?;
         gauges
             .export_epoch_info(&epoch_info, &client)
+            .await
             .context("Failed to export epoch info metrics")?;
-        gauges.export_nodes_info(&nodes, &client, &node_whitelist)?;
+        gauges
+            .export_nodes_info(&nodes, &client, &node_whitelist)
+            .await?;
         if let Some(maxmind) = config.maxmind.clone() {
             // If the MaxMind API is configured, submit queries for any uncached IPs.
             gauges
@@ -213,12 +220,14 @@ and then put real values there.",
             skipped_slots_monitor
                 .as_mut()
                 .unwrap()
-                .export_skipped_slots(&epoch_info, &node_whitelist)
+                .export_skipped_slots(&node_whitelist)
+                .await
                 .context("Failed to export skipped slots")?;
         }
 
         if let Some(x) = &rewards_monitor {
             x.export_rewards(&epoch_info)
+                .await
                 .context("Failed to export rewards")?;
         }
     }

--- a/src/rewards/mod.rs
+++ b/src/rewards/mod.rs
@@ -1,12 +1,12 @@
 use crate::config::Whitelist;
 use crate::rewards::caching::{PubkeyVoterApyMapping, RewardsCache};
-use crate::rpc_extra::with_first_block;
+use crate::rpc_extra::first_block_in_epoch;
 use anyhow::anyhow;
 use log::debug;
 use prometheus_exporter::prometheus::{GaugeVec, IntGaugeVec};
 use serde::{Deserialize, Serialize};
 use solana_account::Account;
-use solana_client::rpc_client::RpcClient;
+use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_config::RpcBlockConfig;
 use solana_clock::Epoch;
 use solana_epoch_info::EpochInfo;
@@ -109,12 +109,12 @@ impl<'a> RewardsMonitor<'a> {
     }
 
     /// Exports reward metrics. APY values will not be re-calculated more than once an epoch.
-    pub fn export_rewards(&self, epoch_info: &EpochInfo) -> anyhow::Result<()> {
+    pub async fn export_rewards(&self, epoch_info: &EpochInfo) -> anyhow::Result<()> {
         let epoch = epoch_info.epoch;
 
         // Possible that rewards haven't shown up yet for this epoch
-        if self.get_rewards_for_epoch(epoch)?.is_some() {
-            let staking_apys = self.calculate_staking_rewards(epoch_info)?;
+        if self.get_rewards_for_epoch(epoch).await?.is_some() {
+            let staking_apys = self.calculate_staking_rewards(epoch_info).await?;
 
             for (
                 voter,
@@ -165,7 +165,7 @@ impl<'a> RewardsMonitor<'a> {
     }
 
     /// Calculates the staking rewards for both the current epoch and the last `MAX_EPOCH_LOOKBACK` epochs.
-    fn calculate_staking_rewards(
+    async fn calculate_staking_rewards(
         &self,
         current_epoch_info: &EpochInfo,
     ) -> anyhow::Result<HashMap<Pubkey, VoterApy>> {
@@ -175,10 +175,12 @@ impl<'a> RewardsMonitor<'a> {
             Ok(apys)
         } else {
             // Filling historical gaps
-            let (_, mut apys) = self.fill_historical_epochs(current_epoch_info)?;
+            let (_, mut apys) = self.fill_historical_epochs(current_epoch_info).await?;
 
             // Fill current epoch and find APY
-            let mapping = self.fill_current_epoch_and_find_apy(current_epoch_info, &mut apys)?;
+            let mapping = self
+                .fill_current_epoch_and_find_apy(current_epoch_info, &mut apys)
+                .await?;
 
             // Write to database
             self.cache
@@ -189,7 +191,7 @@ impl<'a> RewardsMonitor<'a> {
     }
 
     /// Fills `rewards` and `apys` with previous epochs' information, up to `MAX_EPOCH_LOOKBACK` epochs ago.
-    fn fill_historical_epochs(
+    async fn fill_historical_epochs(
         &self,
         current_epoch_info: &EpochInfo,
     ) -> anyhow::Result<(VoterEpochRewardMap, VoterEpochApyMap)> {
@@ -198,12 +200,22 @@ impl<'a> RewardsMonitor<'a> {
         let mut rewards = HashMap::new();
         let mut apys = HashMap::new();
 
-        for epoch in (current_epoch - MAX_EPOCH_LOOKBACK)..current_epoch {
-            // Historical rewards
-            let historical_rewards = self
-                .get_rewards_for_epoch(epoch)?
-                .ok_or_else(|| anyhow!("historical epoch has no rewards"))?;
-            for reward in historical_rewards {
+        // Each epoch's reward block is an independent, potentially slow `getBlock`
+        // (the epoch-boundary block carries the whole network's rewards). Fetch
+        // them concurrently rather than serially, then merge in epoch order.
+        let historical_rewards = futures::future::try_join_all(
+            ((current_epoch - MAX_EPOCH_LOOKBACK)..current_epoch).map(|epoch| async move {
+                let rewards = self
+                    .get_rewards_for_epoch(epoch)
+                    .await?
+                    .ok_or_else(|| anyhow!("historical epoch has no rewards"))?;
+                anyhow::Ok((epoch, rewards))
+            }),
+        )
+        .await?;
+
+        for (epoch, epoch_rewards) in historical_rewards {
+            for reward in epoch_rewards {
                 rewards.insert((reward.pubkey.parse()?, epoch), reward);
             }
 
@@ -221,7 +233,7 @@ impl<'a> RewardsMonitor<'a> {
 
     /// Fills `rewards` and `accounts` with the current epoch's information, either from the cache or RPC.
     /// The cache will be updated.
-    fn fill_current_epoch_and_find_apy(
+    async fn fill_current_epoch_and_find_apy(
         &self,
         current_epoch_info: &EpochInfo,
         apys: &mut VoterEpochApyMap,
@@ -229,7 +241,8 @@ impl<'a> RewardsMonitor<'a> {
         let current_epoch = current_epoch_info.epoch;
 
         let current_rewards = self
-            .get_rewards_for_epoch(current_epoch)?
+            .get_rewards_for_epoch(current_epoch)
+            .await?
             .ok_or_else(|| anyhow!("current epoch has no rewards"))?;
 
         // Extract into staking rewards and validator rewards.
@@ -280,11 +293,21 @@ impl<'a> RewardsMonitor<'a> {
             // for a given voter.
             let mut seen_voters = BTreeSet::new();
 
+            // The epoch duration is constant across every reward in this loop, so
+            // resolve it once instead of on each `calculate_staking_apy` call.
+            let epoch_duration = self
+                .epoch_duration_days(current_epoch - 1, current_epoch_info)
+                .await?
+                .unwrap_or(DEFAULT_EPOCH_LENGTH);
+
             // Chunk into 100
             for chunk in to_query.chunks(100) {
                 let pubkeys: Vec<_> = chunk.iter().map(|r| r.pubkey).collect();
                 debug!("Getting {} accounts", chunk.len());
-                let account_infos = self.client.get_multiple_accounts(pubkeys.as_slice())?;
+                let account_infos = self
+                    .client
+                    .get_multiple_accounts(pubkeys.as_slice())
+                    .await?;
 
                 // For each response in chunk
                 for (reward, account_info) in chunk
@@ -296,8 +319,7 @@ impl<'a> RewardsMonitor<'a> {
                     if let Some(StakingApy { voter, percent }) = calculate_staking_apy(
                         &account_info,
                         &mut seen_voters,
-                        self.epoch_duration_days(current_epoch - 1, current_epoch_info)?
-                            .unwrap_or(DEFAULT_EPOCH_LENGTH),
+                        epoch_duration,
                         reward.lamports as u64,
                         reward.post_balance,
                     )? {
@@ -331,15 +353,14 @@ impl<'a> RewardsMonitor<'a> {
         }
 
         // Epoch durations up to lookback
-        let epoch_durations = (current_epoch - MAX_EPOCH_LOOKBACK + 1..=current_epoch)
-            .map(|epoch| {
-                Ok((
-                    epoch,
-                    self.epoch_duration_days(epoch - 1, current_epoch_info)?
-                        .unwrap_or(DEFAULT_EPOCH_LENGTH),
-                ))
-            })
-            .collect::<anyhow::Result<BTreeMap<_, _>>>()?;
+        let mut epoch_durations = BTreeMap::new();
+        for epoch in current_epoch - MAX_EPOCH_LOOKBACK + 1..=current_epoch {
+            let duration = self
+                .epoch_duration_days(epoch - 1, current_epoch_info)
+                .await?
+                .unwrap_or(DEFAULT_EPOCH_LENGTH);
+            epoch_durations.insert(epoch, duration);
+        }
         let duration_max_epoch_lookback: f64 = epoch_durations.values().sum();
 
         let mut voter_apys = HashMap::new();
@@ -370,7 +391,7 @@ impl<'a> RewardsMonitor<'a> {
     /// Note that this function returns the epoch number exactly as requested. For calculating
     /// rewards, remember that the rewards for epoch `N-1` are in epoch `N`.
     /// Returns `None` if no block time is available for measurement.
-    fn epoch_duration_days(
+    async fn epoch_duration_days(
         &self,
         epoch: Epoch,
         epoch_info: &EpochInfo,
@@ -378,7 +399,9 @@ impl<'a> RewardsMonitor<'a> {
         // If it's the current epoch then we must extrapolate
         if epoch == epoch_info.epoch {
             let first_slot = epoch_info.absolute_slot - epoch_info.slot_index;
-            return if let Some(first_slot_time) = self.client.get_block(first_slot)?.block_time {
+            return if let Some(first_slot_time) =
+                self.client.get_block(first_slot).await?.block_time
+            {
                 let average_slot_time = (OffsetDateTime::now_utc().unix_timestamp()
                     - first_slot_time) as f64
                     / (epoch_info.slot_index) as f64;
@@ -394,10 +417,14 @@ impl<'a> RewardsMonitor<'a> {
             Ok(Some(length))
         } else {
             debug!("Finding epoch {}", epoch);
-            let days_in_epoch = {
-                let first_block_timestamp = |ep| {
-                    with_first_block(self.client, ep, |block| {
-                        let ui_confirmed_block = self.client.get_block_with_config(
+
+            // Timestamp of the first block in `ep`, or `None` if the epoch has no
+            // first block or that block carries no block time.
+            let first_block_timestamp = |ep| async move {
+                if let Some(block) = first_block_in_epoch(self.client, ep).await? {
+                    let ui_confirmed_block = self
+                        .client
+                        .get_block_with_config(
                             block,
                             RpcBlockConfig {
                                 encoding: Some(UiTransactionEncoding::Base64),
@@ -406,23 +433,25 @@ impl<'a> RewardsMonitor<'a> {
                                 commitment: None,
                                 max_supported_transaction_version: Some(0),
                             },
-                        )?;
-                        Ok(ui_confirmed_block.block_time)
-                    })
-                };
-
-                let start_timestamp = first_block_timestamp(epoch)?;
-                let end_timestamp = first_block_timestamp(epoch + 1)?;
-
-                // Timestamps must exist for start and end block
-                if let (Some(start_timestamp), Some(end_timestamp)) =
-                    (start_timestamp, end_timestamp)
-                {
-                    (end_timestamp - start_timestamp) as f64 / SECONDS_IN_DAY as f64
+                        )
+                        .await?;
+                    anyhow::Ok(ui_confirmed_block.block_time)
                 } else {
-                    // Otherwise return early, do not update cache.
-                    return Ok(None);
+                    anyhow::Ok(None)
                 }
+            };
+
+            let start_timestamp = first_block_timestamp(epoch).await?;
+            let end_timestamp = first_block_timestamp(epoch + 1).await?;
+
+            // Timestamps must exist for start and end block
+            let days_in_epoch = if let (Some(start_timestamp), Some(end_timestamp)) =
+                (start_timestamp, end_timestamp)
+            {
+                (end_timestamp - start_timestamp) as f64 / SECONDS_IN_DAY as f64
+            } else {
+                // Otherwise return early, do not update cache.
+                return Ok(None);
             };
 
             self.cache.add_epoch_length(epoch, days_in_epoch)?;
@@ -433,15 +462,15 @@ impl<'a> RewardsMonitor<'a> {
     /// Gets the rewards for `epoch`, either from RPC or cache. The cache will be updated.
     /// Returns `Ok(None)` if there haven't been any rewards in the given epoch yet, `Ok(Some(rewards))` if there have, and
     /// otherwise returns an error.
-    fn get_rewards_for_epoch(&self, epoch: Epoch) -> anyhow::Result<Option<Rewards>> {
+    async fn get_rewards_for_epoch(&self, epoch: Epoch) -> anyhow::Result<Option<Rewards>> {
         if let Some(rewards) = self.cache.get_epoch_rewards(epoch)? {
             Ok(Some(rewards))
+        } else if let Some(block) = first_block_in_epoch(self.client, epoch).await? {
+            let rewards = self.client.get_block(block).await?.rewards;
+            self.cache.add_epoch_rewards(epoch, &rewards)?;
+            Ok(Some(rewards))
         } else {
-            with_first_block(self.client, epoch, |block| {
-                let rewards = self.client.get_block(block)?.rewards;
-                self.cache.add_epoch_rewards(epoch, &rewards)?;
-                Ok(Some(rewards))
-            })
+            Ok(None)
         }
     }
 }

--- a/src/rpc_extra.rs
+++ b/src/rpc_extra.rs
@@ -2,7 +2,7 @@ use crate::config::Whitelist;
 use anyhow::Context;
 use serde_json::Value;
 use solana_client::{
-    rpc_client::RpcClient,
+    nonblocking::rpc_client::RpcClient,
     rpc_request::RpcRequest,
     rpc_response::{RpcContactInfo, RpcVoteAccountStatus},
 };
@@ -16,9 +16,10 @@ use solana_clock::Epoch;
 /// deserialization of the *entire* response. We fetch the raw JSON and coerce
 /// any non-string, non-null `clientId` to its string form before deserializing
 /// into the typed `RpcContactInfo`.
-pub fn get_cluster_nodes_lenient(client: &RpcClient) -> anyhow::Result<Vec<RpcContactInfo>> {
+pub async fn get_cluster_nodes_lenient(client: &RpcClient) -> anyhow::Result<Vec<RpcContactInfo>> {
     let mut raw: Value = client
         .send(RpcRequest::GetClusterNodes, Value::Null)
+        .await
         .context("getClusterNodes RPC call failed")?;
 
     if let Some(nodes) = raw.as_array_mut() {
@@ -34,25 +35,16 @@ pub fn get_cluster_nodes_lenient(client: &RpcClient) -> anyhow::Result<Vec<RpcCo
     serde_json::from_value(raw).context("failed to deserialize getClusterNodes response")
 }
 
-/// Applies `f` to the first block in `epoch`.
-pub fn with_first_block<F, A>(client: &RpcClient, epoch: Epoch, f: F) -> anyhow::Result<Option<A>>
-where
-    F: Fn(u64) -> anyhow::Result<Option<A>>,
-{
-    let epoch_schedule = client.get_epoch_schedule()?;
+/// Returns the slot of the first confirmed block in `epoch`, if any.
+pub async fn first_block_in_epoch(client: &RpcClient, epoch: Epoch) -> anyhow::Result<Option<u64>> {
+    let epoch_schedule = client.get_epoch_schedule().await?;
     let first_slot = epoch_schedule.get_first_slot_in_epoch(epoch);
 
-    // First block in `epoch`.
-    let first_block = client
-        .get_blocks_with_limit(first_slot, 1)?
+    Ok(client
+        .get_blocks_with_limit(first_slot, 1)
+        .await?
         .first()
-        .cloned();
-
-    if let Some(block) = first_block {
-        f(block)
-    } else {
-        Ok(None)
-    }
+        .cloned())
 }
 
 /// Maps vote pubkeys to node pubkeys based on the information provided in `vote_accounts`.

--- a/src/slots.rs
+++ b/src/slots.rs
@@ -1,17 +1,20 @@
 //! Statistics of skipped and validated slots.
 
 use crate::config::Whitelist;
-use log::{debug, log_enabled, Level};
+use log::debug;
 use prometheus_exporter::prometheus::{GaugeVec, IntCounterVec};
-use solana_client::{client_error::ClientError, rpc_client::RpcClient};
-use solana_epoch_info::EpochInfo;
-use std::collections::BTreeMap;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
 
-/// Number of blocks to fetch per request.
-const SLOT_GET_BLOCK_STEP: usize = 1_000;
-
 /// The monitor of skipped and validated slots per validator with minimal internal state.
+///
+/// Each cycle issues a single unfiltered `getBlockProduction` call, which the
+/// RPC node answers from its own epoch-to-date production tracking: a map of
+/// node identity pubkey to `(leader slots, blocks produced)` for the current
+/// epoch. That one cheap call covers the whole epoch so far, so there is no
+/// leader-schedule download, no `getBlocks` range scanning, and no cold-start
+/// backfill against the RPC's long-term block store.
 pub struct SkippedSlotsMonitor<'a> {
     /// Shared Solana RPC client.
     client: &'a RpcClient,
@@ -19,14 +22,13 @@ pub struct SkippedSlotsMonitor<'a> {
     leader_slots: &'a IntCounterVec,
     /// Prometheus gauge.
     skipped_slot_percent: &'a GaugeVec,
-    /// The last observed epoch number.
-    epoch_number: u64,
-    /// The last observed slot index.
-    slot_index: u64,
-    /// The slot leader schedule for the last observed epoch.
-    slot_leaders: BTreeMap<usize, String>,
-    /// `true` iff `SkippedSlotMonitor::export_skipped_slots` already ran.
-    already_ran: bool,
+    /// `range.first_slot` of the last `getBlockProduction` snapshot. Identifies
+    /// the epoch the baseline below belongs to; taken from the response itself
+    /// so an epoch rollover mid-cycle cannot skew the baseline.
+    epoch_first_slot: u64,
+    /// Last observed `(leader slots, blocks produced)` per identity, used to
+    /// increment the counters by the per-cycle delta.
+    last_production: HashMap<String, (usize, usize)>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -56,133 +58,66 @@ impl<'a> SkippedSlotsMonitor<'a> {
             client,
             leader_slots,
             skipped_slot_percent,
-            epoch_number: 0,
-            slot_index: 0,
-            slot_leaders: Default::default(),
-            already_ran: false,
+            epoch_first_slot: 0,
+            last_production: HashMap::new(),
         }
     }
 
-    /// Exports the skipped slot statistics given `epoch_info`.
-    pub fn export_skipped_slots(
-        &mut self,
-        epoch_info: &EpochInfo,
-        node_whitelist: &Whitelist,
-    ) -> anyhow::Result<()> {
-        if self.epoch_number != epoch_info.epoch {
-            // Update the monitor state.
-            self.slot_leaders = self
-                .get_slot_leaders(None)?
-                .into_iter()
-                .filter(|(_, leader)| node_whitelist.contains(leader))
-                .collect();
-            self.epoch_number = epoch_info.epoch;
-            self.slot_index = epoch_info.slot_index;
-            debug!("SkippedSlotsMonitor state updated");
-        } else if self.slot_index == epoch_info.slot_index {
-            debug!("At the slot index");
-            return Ok(());
-        }
+    /// Exports the skipped slot statistics for the current epoch.
+    pub async fn export_skipped_slots(&mut self, node_whitelist: &Whitelist) -> anyhow::Result<()> {
+        let production = self.client.get_block_production().await?.value;
 
-        let first_slot = epoch_info.absolute_slot - epoch_info.slot_index;
-        let (abs_range_start, range_start) = if self.already_ran {
-            // Start from the last seen slot if already ran before.
-            (first_slot + self.slot_index, self.slot_index)
-        } else {
-            // Start from the first slot in the current epoch if running for the first time.
-            self.already_ran = true;
-            (first_slot, 0)
-        };
-        let range_end = epoch_info.slot_index;
-        let abs_range_end = first_slot + range_end;
-
-        let mut confirmed_blocks = vec![];
-        for abs_range_step in (abs_range_start..abs_range_end).step_by(SLOT_GET_BLOCK_STEP) {
-            let abs_range_step_end =
-                abs_range_end.min(abs_range_step + SLOT_GET_BLOCK_STEP as u64 - 1);
+        if production.range.first_slot != self.epoch_first_slot {
+            // New epoch: production numbers restart from zero, so the counter
+            // baseline must too.
+            self.epoch_first_slot = production.range.first_slot;
+            self.last_production.clear();
             debug!(
-                "Getting confirmed blocks from {} to {}",
-                abs_range_step, abs_range_step_end
-            );
-            confirmed_blocks.extend(
-                self.client
-                    .get_blocks(abs_range_step, Some(abs_range_step_end))?,
+                "SkippedSlotsMonitor reset for epoch starting at slot {}",
+                self.epoch_first_slot
             );
         }
-        confirmed_blocks.sort_unstable();
-        debug!(
-            "Confirmed blocks from {} to {}: {:?}",
-            abs_range_start, abs_range_end, confirmed_blocks
-        );
-        let mut feed = self.leader_slots.local();
-        for slot_in_epoch in range_start..range_end {
-            // If there is no slot then it must have been filtered because of whitelist.
-            let leader = if let Some(leader) = self.slot_leaders.get(&(slot_in_epoch as usize)) {
-                leader
-            } else {
-                continue;
-            };
 
-            let absolute_slot = first_slot + slot_in_epoch;
-            let status = if confirmed_blocks.binary_search(&absolute_slot).is_ok() {
-                SlotStatus::Validated
-            } else {
-                SlotStatus::Skipped
-            };
-            if log_enabled!(Level::Debug)
-                && (slot_in_epoch < range_start + 50 || range_end - 50 < slot_in_epoch)
-            {
-                // Log only a subset of slots on the first run.
-                debug!("Leader {} {} slot {}", leader, status, absolute_slot);
+        let mut snapshot = HashMap::new();
+        let mut feed = self.leader_slots.local();
+        for (identity, (leader_slots, blocks_produced)) in production.by_identity {
+            if !node_whitelist.contains(&identity) {
+                continue;
             }
-            feed.with_label_values(&[leader, &status.to_string()]).inc();
+
+            let (prev_leader_slots, prev_blocks_produced) = self
+                .last_production
+                .get(&identity)
+                .copied()
+                .unwrap_or_default();
+            // Saturating arithmetic absorbs the occasional regression when a
+            // load-balanced RPC pool answers consecutive calls from nodes with
+            // slightly different views of the epoch.
+            let delta_validated = blocks_produced.saturating_sub(prev_blocks_produced);
+            let delta_skipped = leader_slots
+                .saturating_sub(prev_leader_slots)
+                .saturating_sub(delta_validated);
+            feed.with_label_values(&[&identity, &SlotStatus::Validated.to_string()])
+                .inc_by(delta_validated as u64);
+            feed.with_label_values(&[&identity, &SlotStatus::Skipped.to_string()])
+                .inc_by(delta_skipped as u64);
+
+            // The percentage is set from the epoch-to-date absolutes rather
+            // than the counters, so it is exact regardless of counter resets.
+            if leader_slots > 0 {
+                let skipped = leader_slots - blocks_produced.min(leader_slots);
+                let skipped_percent = (skipped as f64 / leader_slots as f64) * 100.0;
+                self.skipped_slot_percent
+                    .get_metric_with_label_values(&[&identity])
+                    .map(|c| c.set(skipped_percent))?;
+            }
+
+            snapshot.insert(identity, (leader_slots, blocks_produced));
         }
         feed.flush();
+        self.last_production = snapshot;
 
-        // Update skipped slot percentages.
-        for slot_in_epoch in range_start..range_end {
-            let leader = if let Some(leader) = self.slot_leaders.get(&(slot_in_epoch as usize)) {
-                leader
-            } else {
-                continue;
-            };
-            let get_count = |slot_status: SlotStatus| {
-                self.leader_slots
-                    .get_metric_with_label_values(&[leader, &slot_status.to_string()])
-                    .map(|m| m.get())
-                    .unwrap_or_default()
-            };
-            let skipped_count = get_count(SlotStatus::Skipped);
-            let validated_count = get_count(SlotStatus::Validated);
-            // total_count > 0 since either skipped_count > 0 or validated_count > 0. Hence the
-            // result of division by total_count is always defined.
-            let total_count = validated_count + skipped_count;
-            assert!(total_count > 0);
-            let skipped_percent = (skipped_count as f64 / total_count as f64) * 100.0;
-            self.skipped_slot_percent
-                .get_metric_with_label_values(&[leader])
-                .map(|c| c.set(skipped_percent))?;
-        }
-
-        self.slot_index = epoch_info.slot_index;
-        debug!("Exported leader slots and updated the slot index");
+        debug!("Exported leader slots");
         Ok(())
-    }
-
-    /// Gets the leader schedule internally and inverts it, returning the slot leaders in `epoch` or
-    /// in the current epoch if `epoch` is `None`.
-    fn get_slot_leaders(&self, epoch: Option<u64>) -> Result<BTreeMap<usize, String>, ClientError> {
-        let mut slot_leaders = BTreeMap::new();
-        match self.client.get_leader_schedule(epoch)? {
-            None => (),
-            Some(leader_schedule) => {
-                for (pk, slots) in leader_schedule {
-                    for slot in slots {
-                        slot_leaders.insert(slot, pk.clone());
-                    }
-                }
-            }
-        }
-        Ok(slot_leaders)
     }
 }


### PR DESCRIPTION
## Problem

The exporter could take **minutes to start serving `/metrics`** on a cold start, and in orchestrated deployments this showed up as a **restart loop**: the health check on `/metrics` timed out, the task was killed, and the next cold start hit the same wall.

Root cause: on first run, the skipped-slots monitor backfilled the whole epoch with sequential 1,000-slot `getBlocks` calls (~423 calls late in an epoch). Those ranges age out of the validator ledger and are served from the RPC's long-term block store, whose latency is heavy-tailed — windows measured at up to ~134s, with hard failures above 100k-slot ranges. A single timeout exits the process, restarting the loop.

## Change

Rewrite the monitor on **`getBlockProduction`**: one unfiltered call per cycle returns every validator's epoch-to-date `(leader slots, blocks produced)` from the RPC node's own epoch tracking — never the long-term store. The leader-schedule download, the windowed `getBlocks` scan, the cold-start backfill, and its tunables are all removed (`src/slots.rs`: 216 → 122 lines).

- **`solana_leader_slots` stays a counter** — incremented by per-cycle deltas against the previous snapshot (saturating, so slightly divergent views behind a load-balanced RPC pool can't underflow). Existing `rate()`/`increase()` dashboards are unaffected.
- **`solana_skipped_slot_percent` is set from epoch-to-date absolutes** — exact across restarts and now covers the whole epoch, including slots before the exporter started (the old code could never see those).
- **Epoch rollover** is detected from the response's own `range.first_slot`, so a cycle straddling a boundary can't skew the baseline.

Groundwork included in this PR:

- Switch to the **nonblocking `RpcClient`**; all export paths are async.
- **Concurrent** node-balance fetches and historical reward-epoch fetches; per-epoch duration lookup hoisted out of the per-account loop.
  - Interim **120s RPC client timeout** so one slow call (e.g. epoch-boundary `getBlock` on the rewards path) doesn't abort the cycle and exit the process — to be lowered when per-export error isolation lands (follow-up).
  
- `.gitignore` local configs (tokened RPC URLs) and test artifacts.

## Verification

- `cargo fmt` / `clippy` / `build --release` clean.
- `getBlockProduction` smoke-tested on mainnet, testnet, and other network endpoints.
- **Cold start to first complete update: 2.5s on mainnet (~95% through the epoch — the old worst case, projected ~30 min), 4.1s on testnet.** Zero `getBlocks` calls issued; peak RSS 35 MB.
- Metric values cross-checked against direct `getBlockProduction` responses: all mainnet identities and both testnet identities match exactly (`validated == blocks_produced`, `validated + skipped == leader_slots`).
- Restart test: percent gauges identical across a kill/restart; counters re-baseline to epoch-to-date totals (ordinary Prometheus counter reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
