### PR TITLE
Stop skipped-slots errors from crashing the exporter on testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3445,6 +3445,7 @@ dependencies = [
  "solana-account",
  "solana-client",
  "solana-clock",
+ "solana-commitment-config",
  "solana-epoch-info",
  "solana-pubkey 3.0.0",
  "solana-reward-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ solana-account = "3.4.0"
 solana-pubkey = "3.0.0"
 solana-clock = "3.1.0"
 solana-epoch-info = "3.1.0"
+solana-commitment-config = "3.1.1"
 sled = "^0.34.6"
 bincode = "^1.3.3"
 serde = { version = "^1.0.126", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,25 +186,45 @@ and then put real values there.",
         let _guard = exporter.wait_duration(duration);
         debug!("Updating metrics");
 
-        // Get metrics we need
-        let epoch_info = client.get_epoch_info().await?;
-        let nodes = rpc_extra::get_cluster_nodes_lenient(&client).await?;
-        let vote_accounts = client.get_vote_accounts().await?;
+        // Base data every export below depends on. If any of these fail there
+        // is nothing meaningful to publish this cycle, so log and wait for the
+        // next tick instead of propagating out of `main` — a `?` here exits the
+        // process and drops every metric until the orchestrator restarts us.
+        let base = async {
+            let epoch_info = client.get_epoch_info().await?;
+            let nodes = rpc_extra::get_cluster_nodes_lenient(&client).await?;
+            let vote_accounts = client.get_vote_accounts().await?;
+            anyhow::Ok((epoch_info, nodes, vote_accounts))
+        }
+        .await;
+        let (epoch_info, nodes, vote_accounts) = match base {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("Skipping update cycle, base RPC fetch failed: {e:#}");
+                continue;
+            }
+        };
         let node_whitelist = rpc_extra::node_pubkeys(&vote_accounts_whitelist, &vote_accounts);
 
-        gauges
-            .export_vote_accounts(&vote_accounts)
-            .context("Failed to export vote account metrics")?;
-        gauges
-            .export_epoch_info(&epoch_info, &client)
-            .await
-            .context("Failed to export epoch info metrics")?;
-        gauges
+        // Each export is isolated: a transient error on one (e.g. testnet
+        // `getBlockProduction` racing the node's slot history) is logged and the
+        // remaining exports still publish, rather than one failure aborting the
+        // whole cycle or exiting the process.
+        if let Err(e) = gauges.export_vote_accounts(&vote_accounts) {
+            warn!("Failed to export vote account metrics: {e:#}");
+        }
+        if let Err(e) = gauges.export_epoch_info(&epoch_info, &client).await {
+            warn!("Failed to export epoch info metrics: {e:#}");
+        }
+        if let Err(e) = gauges
             .export_nodes_info(&nodes, &client, &node_whitelist)
-            .await?;
+            .await
+        {
+            warn!("Failed to export node info metrics: {e:#}");
+        }
         if let Some(maxmind) = config.maxmind.clone() {
             // If the MaxMind API is configured, submit queries for any uncached IPs.
-            gauges
+            if let Err(e) = gauges
                 .export_ip_addresses(
                     &nodes,
                     &vote_accounts,
@@ -213,22 +233,26 @@ and then put real values there.",
                     &node_whitelist,
                 )
                 .await
-                .context("Failed to export IP address info metrics")?;
+            {
+                warn!("Failed to export IP address info metrics: {e:#}");
+            }
         }
 
         if enable_skipped_slots {
-            skipped_slots_monitor
+            if let Err(e) = skipped_slots_monitor
                 .as_mut()
                 .unwrap()
                 .export_skipped_slots(&node_whitelist)
                 .await
-                .context("Failed to export skipped slots")?;
+            {
+                warn!("Failed to export skipped slots: {e:#}");
+            }
         }
 
         if let Some(x) = &rewards_monitor {
-            x.export_rewards(&epoch_info)
-                .await
-                .context("Failed to export rewards")?;
+            if let Err(e) = x.export_rewards(&epoch_info).await {
+                warn!("Failed to export rewards: {e:#}");
+            }
         }
     }
 }

--- a/src/slots.rs
+++ b/src/slots.rs
@@ -4,6 +4,8 @@ use crate::config::Whitelist;
 use log::debug;
 use prometheus_exporter::prometheus::{GaugeVec, IntCounterVec};
 use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_client::rpc_config::RpcBlockProductionConfig;
+use solana_commitment_config::CommitmentConfig;
 use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
 
@@ -65,7 +67,25 @@ impl<'a> SkippedSlotsMonitor<'a> {
 
     /// Exports the skipped slot statistics for the current epoch.
     pub async fn export_skipped_slots(&mut self, node_whitelist: &Whitelist) -> anyhow::Result<()> {
-        let production = self.client.get_block_production().await?.value;
+        // Pin the query to `finalized`. With an unset commitment and `range: None`
+        // the node derives `last_slot = bank.slot()` for whichever (often
+        // unrooted, tip) bank it picks, then bound-checks that range against its
+        // own SlotHistory sysvar. On testnet that bank's slot routinely runs
+        // ahead of the newest slot in history (skipped slots, forks, snapshot
+        // restarts), so the node rejects its own computed range with
+        // "lastSlot ... is too large" / "No slot history". A finalized bank's
+        // slot is rooted and therefore present in that same bank's SlotHistory,
+        // so the self-check cannot trip. `range: None` still scopes the response
+        // to the current epoch.
+        let production = self
+            .client
+            .get_block_production_with_config(RpcBlockProductionConfig {
+                identity: None,
+                range: None,
+                commitment: Some(CommitmentConfig::finalized()),
+            })
+            .await?
+            .value;
 
         if production.range.first_slot != self.epoch_first_slot {
             // New epoch: production numbers restart from zero, so the counter


### PR DESCRIPTION
## Problem

After 0.7.0 (`e390ec` — replace getBlocks scan with `getBlockProduction`), the exporter on **testnet** intermittently dies with:

```
Error: Failed to export skipped slots

Caused by:
    0: RPC response error -32602: lastSlot, 415466409, is too large; max 415466374;
    1: RPC response error -32021: No slot history;
```

Each block in the logs is preceded by the `exporting metrics to …` startup line — i.e. the process is **crash-restarting**, dropping *all* metrics each time, not just skipped slots.

### Root cause

`get_block_production()` sends `params: null`, so the RPC node derives the range itself: `last_slot = bank.slot()` for whichever (often unrooted, tip) bank it selects, then bound-checks that range against its own **SlotHistory sysvar** ([`rpc.rs`](https://github.com/rpcpool/solana/blob/master/rpc/src/rpc.rs)):

```rust
let (first_slot, last_slot) = match config.range {
    None => (epoch_first_slot, bank.slot()),
    ...
};
let slot_history = bank.get_slot_history();
if last_slot > slot_history.newest() {
    return Err(... "lastSlot, {}, is too large; max {}" ...);
}
```

On testnet the tip routinely runs ahead of the newest slot in history (frequent skipped slots, forks, snapshot restarts), so the node rejects its own computed range. The pre-0.7.0 code built its own `getBlocks` windows from the leader schedule over slots it knew existed, so it never hit this.

Because every export in the update loop propagated errors with `?`, any such failure exited `main` → process exit → orchestrator restart loop.

## Fix

**`slots.rs` — pin `getBlockProduction` to `finalized`.** A finalized bank's slot is rooted and therefore present in that same bank's SlotHistory, so the self-bound-check cannot trip. `range: None` still scopes the response to the current epoch, so epoch-rollover handling is unchanged.

**`main.rs` — per-export error isolation.** Base fetches (`getEpochInfo`, `getClusterNodes`, `getVoteAccounts`) are prerequisites and skip the cycle on failure; each export then runs independently so a transient error on one (e.g. a backend with genuinely no slot history yet) is logged and the remaining exports still publish, instead of exiting the process. This is the per-export error isolation the 0.7.0 commit deferred.

Together: an intermittent testnet error now costs one cycle of one metric rather than a full-exporter restart.

## Notes
- The `-32021 No slot history` case (a backend with no usable history yet) can't be fixed by range tuning — it's handled by the error isolation.
- Not addressed: the symmetric `firstSlot … too small` risk after a mid-epoch snapshot restart. It's now caught gracefully by the isolation rather than crashing; happy to harden it with `minimumLedgerSlot` clamping if wanted.

## Validation
- `cargo build` ✓
- `cargo clippy --all-targets` ✓ (clean)
- `cargo fmt --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)