### PR TITLE
Add cluster-wide solana_gossip_node_info metric (IP -> identity/vote account)

### DIFF
--- a/sample_config.toml
+++ b/sample_config.toml
@@ -10,6 +10,10 @@ staking_account_whitelist = [
     'bb',
     'cc'
 ]
+# Export cluster-wide gossip node info (solana_gossip_node_info), one series per
+# cluster node mapping identity/vote account -> gossip/TVU/TPU IPs. NOT filtered
+# by the whitelists, so it adds one series per network node (thousands).
+enable_gossip_node_info = false
 
 [maxmind]
 username = "12345"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,4 +30,9 @@ pub struct ExporterConfig {
     pub enable_rewards: Option<bool>,
     /// Whjether to process skipped slots data or not
     pub enable_skipped_slots: Option<bool>,
+    /// Whether to export cluster-wide gossip node info (`solana_gossip_node_info`),
+    /// one series per cluster node. Unlike the other metrics this is NOT filtered
+    /// by the vote-account whitelist, so it adds one series per network node
+    /// (thousands). Defaults to `false`.
+    pub enable_gossip_node_info: Option<bool>,
 }

--- a/src/gauges.rs
+++ b/src/gauges.rs
@@ -5,6 +5,7 @@ use crate::geolocation::caching::GeolocationCache;
 use crate::geolocation::get_rpc_contact_ip;
 use crate::geolocation::identifier::DatacenterIdentifier;
 use crate::rpc_extra::first_block_in_epoch;
+use crate::rpc_extra::GossipNode;
 use anyhow::{anyhow, Context};
 use futures::TryFutureExt;
 use geoip2_city::CityApiResponse;
@@ -29,6 +30,26 @@ pub const PUBKEY_LABEL: &str = "pubkey";
 pub const IDENTITY_LABEL: &str = "identity";
 /// Label used for peoch
 pub const EPOCH_LABEL: &str = "epoch";
+
+/// Extracts the bare IP from an optional `ip:port` socket address string,
+/// returning an empty string when absent. Dashboards join on bare source IPs
+/// (e.g. `xdp_proxy_src_pkts.src`), so the port must be stripped. Falls back to
+/// the substring before the last `:` for robustness; IPv6 literals advertised by
+/// gossip are bracketed (`[::1]:8001`) so the brackets are trimmed too.
+fn ip_of(socket_addr: &Option<String>) -> String {
+    match socket_addr {
+        None => String::new(),
+        Some(s) => match s.parse::<std::net::SocketAddr>() {
+            Ok(addr) => addr.ip().to_string(),
+            Err(_) => s
+                .rsplit_once(':')
+                .map(|(host, _)| host)
+                .unwrap_or(s)
+                .trim_matches(|c| c == '[' || c == ']')
+                .to_string(),
+        },
+    }
+}
 
 pub struct PrometheusGauges {
     pub active_validators: IntGaugeVec,
@@ -57,6 +78,7 @@ pub struct PrometheusGauges {
     pub node_versions: IntGaugeVec,
     pub nodes: IntGauge,
     pub average_slot_time: Gauge,
+    pub gossip_node_info: IntGaugeVec,
     // Connection pool for querying
     client: reqwest::Client,
     vote_accounts_whitelist: Whitelist,
@@ -201,6 +223,23 @@ impl PrometheusGauges {
             nodes: register_int_gauge!("solana_nodes", "Number of nodes").unwrap(),
             average_slot_time: register_gauge!("solana_average_slot_time", "Average slot time")
                 .unwrap(),
+            gossip_node_info: register_int_gauge_vec!(
+                "solana_gossip_node_info",
+                "Cluster-wide gossip info: one series per cluster node mapping its \
+                 identity/vote account to its gossip/TVU/TPU IP addresses. Value is always 1.",
+                &[
+                    IDENTITY_LABEL,
+                    // Named `vote_key` (not `vote_account`) to match the existing
+                    // validator_info{identity, vote_key} convention, so dashboards
+                    // can join our-node and network-wide metrics uniformly.
+                    "vote_key",
+                    "gossip_ip",
+                    "tvu_ip",
+                    "tpu_ip",
+                    "version",
+                ]
+            )
+            .unwrap(),
             client: reqwest::Client::new(),
             vote_accounts_whitelist,
         }
@@ -379,6 +418,56 @@ impl PrometheusGauges {
         Ok(())
     }
 
+    /// Exports cluster-wide gossip node info: one `solana_gossip_node_info`
+    /// series per node in the cluster, mapping its identity and (where it has
+    /// one) vote account to its bare gossip/TVU/TPU IP addresses.
+    ///
+    /// Unlike [`export_nodes_info`], this is **not** filtered by the whitelist —
+    /// it covers every node in `getClusterNodes` so dashboards can resolve any
+    /// source IP on the network back to a node identity. The gauge is fully
+    /// reset each cycle so series for nodes/IPs that left the cluster do not
+    /// accumulate (the cluster has thousands of nodes with IP churn).
+    pub fn export_gossip_node_info(
+        &self,
+        nodes: &[GossipNode],
+        vote_accounts: &RpcVoteAccountStatus,
+    ) -> anyhow::Result<()> {
+        // node identity pubkey -> vote account pubkey (non-voting nodes absent).
+        let vote_by_node: HashMap<&str, &str> = vote_accounts
+            .current
+            .iter()
+            .chain(vote_accounts.delinquent.iter())
+            .map(|v| (v.node_pubkey.as_str(), v.vote_pubkey.as_str()))
+            .collect();
+
+        // Reset so departed nodes / stale IPs do not linger between cycles.
+        self.gossip_node_info.reset();
+
+        for node in nodes {
+            let vote_account = vote_by_node
+                .get(node.pubkey.as_str())
+                .copied()
+                .unwrap_or("");
+            let gossip_ip = ip_of(&node.gossip);
+            let tvu_ip = ip_of(&node.tvu);
+            let tpu_ip = ip_of(&node.tpu);
+            let version = node.version.as_deref().unwrap_or("unknown");
+
+            self.gossip_node_info
+                .get_metric_with_label_values(&[
+                    &node.pubkey,
+                    vote_account,
+                    &gossip_ip,
+                    &tvu_ip,
+                    &tpu_ip,
+                    version,
+                ])
+                .map(|m| m.set(1))?;
+        }
+
+        Ok(())
+    }
+
     /// Exports gauges for geolocation of validators
     pub async fn export_ip_addresses(
         &self,
@@ -546,5 +635,32 @@ impl PrometheusGauges {
 impl Default for PrometheusGauges {
     fn default() -> Self {
         Self::new(Whitelist::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ip_of;
+
+    #[test]
+    fn ip_of_strips_port() {
+        assert_eq!(
+            ip_of(&Some("64.130.42.197:8002".to_string())),
+            "64.130.42.197"
+        );
+    }
+
+    #[test]
+    fn ip_of_handles_none_and_empty() {
+        assert_eq!(ip_of(&None), "");
+        assert_eq!(ip_of(&Some(String::new())), "");
+    }
+
+    #[test]
+    fn ip_of_strips_ipv6_brackets_and_port() {
+        assert_eq!(
+            ip_of(&Some("[2001:db8::1]:8001".to_string())),
+            "2001:db8::1"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> anyhow::Result<()> {
             staking_account_whitelist: Some(Whitelist::default()),
             enable_rewards: Some(true),
             enable_skipped_slots: Some(true),
+            enable_gossip_node_info: Some(false),
         };
 
         let location = sc
@@ -153,6 +154,7 @@ and then put real values there.",
     let staking_account_whitelist = config.staking_account_whitelist.unwrap_or_default();
     let enable_rewards = config.enable_rewards.unwrap_or(true);
     let enable_skipped_slots = config.enable_skipped_slots.unwrap_or(true);
+    let enable_gossip_node_info = config.enable_gossip_node_info.unwrap_or(false);
 
     let gauges = PrometheusGauges::new(vote_accounts_whitelist.clone());
     let mut skipped_slots_monitor = if enable_skipped_slots {
@@ -192,12 +194,17 @@ and then put real values there.",
         // process and drops every metric until the orchestrator restarts us.
         let base = async {
             let epoch_info = client.get_epoch_info().await?;
-            let nodes = rpc_extra::get_cluster_nodes_lenient(&client).await?;
+            // Fetch getClusterNodes once and derive both the typed view (used by
+            // the whitelisted exporters) and, when enabled, the raw gossip view
+            // (which preserves the `tvu` field the typed struct drops).
+            let raw_nodes = rpc_extra::get_cluster_nodes_raw(&client).await?;
+            let nodes: Vec<_> = serde_json::from_value(raw_nodes.clone())
+                .context("failed to deserialize getClusterNodes response")?;
             let vote_accounts = client.get_vote_accounts().await?;
-            anyhow::Ok((epoch_info, nodes, vote_accounts))
+            anyhow::Ok((epoch_info, raw_nodes, nodes, vote_accounts))
         }
         .await;
-        let (epoch_info, nodes, vote_accounts) = match base {
+        let (epoch_info, raw_nodes, nodes, vote_accounts) = match base {
             Ok(v) => v,
             Err(e) => {
                 warn!("Skipping update cycle, base RPC fetch failed: {e:#}");
@@ -221,6 +228,12 @@ and then put real values there.",
             .await
         {
             warn!("Failed to export node info metrics: {e:#}");
+        }
+        if enable_gossip_node_info {
+            let gossip_nodes = rpc_extra::parse_gossip_nodes(&raw_nodes);
+            if let Err(e) = gauges.export_gossip_node_info(&gossip_nodes, &vote_accounts) {
+                warn!("Failed to export gossip node info metrics: {e:#}");
+            }
         }
         if let Some(maxmind) = config.maxmind.clone() {
             // If the MaxMind API is configured, submit queries for any uncached IPs.

--- a/src/rpc_extra.rs
+++ b/src/rpc_extra.rs
@@ -1,22 +1,57 @@
 use crate::config::Whitelist;
 use anyhow::Context;
+use serde::Deserialize;
 use serde_json::Value;
 use solana_client::{
-    nonblocking::rpc_client::RpcClient,
-    rpc_request::RpcRequest,
-    rpc_response::{RpcContactInfo, RpcVoteAccountStatus},
+    nonblocking::rpc_client::RpcClient, rpc_request::RpcRequest, rpc_response::RpcVoteAccountStatus,
 };
 use solana_clock::Epoch;
 
-/// Fetches the cluster nodes, tolerating a non-conformant `clientId` field.
+/// A cluster node as returned by `getClusterNodes`, preserving the gossip-table
+/// address fields that the typed `RpcContactInfo` (solana-client 4.0.0) drops —
+/// notably `tvu`, which is required to correlate shred (TVU) traffic back to a
+/// node identity. Captured directly from the raw RPC JSON so we don't issue a
+/// second `getClusterNodes` call against the (large) cluster every cycle.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GossipNode {
+    /// Node identity pubkey, base-58.
+    pub pubkey: String,
+    /// Gossip socket address (`ip:port`), if advertised.
+    pub gossip: Option<String>,
+    /// TVU (shred-ingress) socket address (`ip:port`), if advertised.
+    pub tvu: Option<String>,
+    /// TPU socket address (`ip:port`), if advertised.
+    pub tpu: Option<String>,
+    /// Software version, if advertised.
+    pub version: Option<String>,
+}
+
+/// Parses an already-fetched `getClusterNodes` JSON payload (as returned by
+/// [`get_cluster_nodes_raw`]) into [`GossipNode`]s. Nodes that fail to
+/// deserialize individually are skipped rather than failing the whole batch.
+pub fn parse_gossip_nodes(raw: &Value) -> Vec<GossipNode> {
+    raw.as_array()
+        .map(|nodes| {
+            nodes
+                .iter()
+                .filter_map(|node| serde_json::from_value::<GossipNode>(node.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Fetches the raw `getClusterNodes` JSON, tolerating a non-conformant
+/// `clientId` field.
 ///
 /// solana-client 4.0.0 added `RpcContactInfo.client_id: Option<String>` and
 /// parses it strictly as a string. Some networks (e.g. doublezero) return
-/// `clientId` as an integer, which makes `RpcClient::get_cluster_nodes` fail
-/// deserialization of the *entire* response. We fetch the raw JSON and coerce
-/// any non-string, non-null `clientId` to its string form before deserializing
-/// into the typed `RpcContactInfo`.
-pub async fn get_cluster_nodes_lenient(client: &RpcClient) -> anyhow::Result<Vec<RpcContactInfo>> {
+/// `clientId` as an integer, which makes the typed deserialization fail for the
+/// *entire* response. We coerce any non-string, non-null `clientId` to its
+/// string form before returning the raw `Value`, so callers can deserialize it
+/// into multiple typed views (e.g. `RpcContactInfo` and [`GossipNode`]) without
+/// re-issuing the RPC call.
+pub async fn get_cluster_nodes_raw(client: &RpcClient) -> anyhow::Result<Value> {
     let mut raw: Value = client
         .send(RpcRequest::GetClusterNodes, Value::Null)
         .await
@@ -32,7 +67,7 @@ pub async fn get_cluster_nodes_lenient(client: &RpcClient) -> anyhow::Result<Vec
         }
     }
 
-    serde_json::from_value(raw).context("failed to deserialize getClusterNodes response")
+    Ok(raw)
 }
 
 /// Returns the slot of the first confirmed block in `epoch`, if any.


### PR DESCRIPTION
## What

Adds an opt-in Prometheus metric that exports **one series per cluster node**, mapping each node's identity and vote key to its **bare gossip / TVU / TPU IP addresses**:

```
solana_gossip_node_info{identity, vote_key, gossip_ip, tvu_ip, tpu_ip, version} 1
```

Gated behind a new config flag `enable_gossip_node_info` (default **false**).

## Why

We need a network-wide IP -> pubkey mapping in metrics so dashboards can resolve arbitrary source IPs back to a node identity. Driving use case: the **Shred sources** dashboard, which classifies shred ingress via `xdp_proxy_src_pkts{src,dst,...}` and wants to dynamically resolve "unmapped senders" (`src` IPs) to validator pubkeys instead of a static partner map. `tvu_ip` is the join key for shred (TVU) traffic.

No existing metric covers this: `validator_info` / `solana_node_*` are scoped to our whitelisted validators; `doublezero_validator_dz_ip_info` only covers DoubleZero users.

## Scope / safety

- **Existing per-validator metrics are unchanged** — they remain filtered by the vote-account whitelist. Only this new metric is cluster-wide.
- Default-off, so devnet/testnet/pythnet/doublezero groups don't silently gain thousands of series.
- `vote_key` label name matches existing `validator_info{identity, vote_key}` for cross-metric join uniformity.

## Implementation notes

- Reuses the single `getClusterNodes` fetch per cycle (`get_cluster_nodes_raw`), deserializing the raw JSON into a new `GossipNode` struct that preserves the `tvu` field the typed `RpcContactInfo` (solana-client 4.0.0) drops. No extra RPC call.
- IP label values are **bare** (port stripped via `ip_of`, incl. IPv6 bracket handling) so they join directly against bare source IPs.
- The gauge vec is `.reset()` each cycle to bound cardinality under cluster IP churn (~4700 mainnet nodes).
- `vote_key` is the empty string for non-voting nodes (e.g. RPC nodes) rather than dropping them — they still send shreds.
- Unit tests cover `ip_of`. `cargo check`, `cargo test`, `cargo clippy` (0 warnings), `cargo fmt` all clean.

## Dashboard consumer note (important)

Live `getClusterNodes` (mainnet, ~4705 nodes) has a small number of **duplicate IPs** (multi-node operators / NAT): ~10 gossip IPs across 34 nodes, ~5 tvu IPs across 15 nodes. A raw `* on(src) group_left(...)` join against these will error with "duplicate series for match group". Dashboards must aggregate the right-hand side, e.g. `max by (tvu_ip) (solana_gossip_node_info)` or `topk(1, ...)`. Also note many nodes advertise no TPU (`tpu_ip` empty), and our own validator advertises no TPU via RPC — prefer `tvu_ip` (shreds) / `gossip_ip` as join keys.

## Deploy follow-up (separate, in rpcpool/terraform PR #1466)

1. Merge this PR.
2. Build the binary via `build-release.yml` (rpcpool/Binaries-ci) so the tagged release lands in GCS.
3. Bump `release_version` in the Nomad job to that tag, enable on mainnet (already staged in terraform#1466). Apply via Atlantis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEDLw7BmpWZGyqVr6UQSFe