### PR TITLE
feat(exporter): add validator node info and stake metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "solana-exporter"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solana-exporter"
 description = "Prometheus exporter for the Solana validator"
-version = "0.4.2"
+version = "0.5.0"
 authors = [
     "Vladimir Komendantskiy <komendantsky@gmail.com>",
     "Anson Cheung <git@anson-cheung.com>"
@@ -37,7 +37,7 @@ reqwest = { version = "^0.11.3", default-features = false, features = ["json", "
 time = { version = "^0.2.26", features = ["serde"] }
 geoip2-city = { version = "^0.1.0", features = ["serde_support"] }
 anyhow = "^1.0.40"
-tokio = "^1.6.0"
+tokio = { version = "^1.6.0", features = ["macros", "rt-multi-thread", "time"] }
 futures = "^0.3.15"
 dirs = "^3.0.2"
 semver = "^1.0.0"

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -15,6 +15,18 @@ staking_account_whitelist = [
 # by the whitelists, so it adds one series per network node (thousands).
 enable_gossip_node_info = false
 
+# Export the cluster-wide solana_validator_node_info enrichment metric
+# (identity -> vote account, version, client, country, ASN, dz_edge) plus
+# solana_validator_node_stake. Covers every cluster node (thousands) and starts
+# the ip-api geolocation background task.
+enable_validator_node_info = false
+# ip-api base URL for enrichment geolocation (free tier default).
+ip_api_base_url = "http://ip-api.com"
+# Resolve DoubleZero edge membership for the dz_edge label (adds egress to the
+# DZ publisher endpoint).
+enable_dz_edge = false
+dz_publisher_url = "https://data.malbeclabs.com/api/dz/publisher-check"
+
 [maxmind]
 username = "12345"
 password = "replace_me"

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,5 +1,5 @@
 name: Solana Prometheus Exporter
-version: "0.3.0"
+version: "0.5.0"
 author: Vladimir Komendantskiy <komendantsky@gmail.com>
 about: Publishes Solana validator metrics to Prometheus
 args:

--- a/src/client_id.rs
+++ b/src/client_id.rs
@@ -1,0 +1,106 @@
+//! Resolves the `clientId` advertised in `getClusterNodes` to a friendly client
+//! name (Solana v4.0 exposes it as a string). Kept dependency-free so it can be
+//! shared verbatim with other tooling.
+
+const KNOWN_CLIENTS: &[(u16, &str)] = &[
+    (0, "SolanaLabs"),
+    (1, "JitoLabs"),
+    (2, "Frankendancer"),
+    (3, "Agave"),
+    (4, "AgavePaladin"),
+    (5, "Firedancer"),
+    (6, "AgaveBam"),
+    (7, "Sig"),
+    (8, "Rakurai"),
+    (9, "HarmonicFiredancer"),
+    (10, "HarmonicAgave"),
+    (11, "HarmonicFrankendancer"),
+    (12, "FireBAM"),
+    (13, "Raiku"),
+];
+
+/// Resolves a raw `clientId` (name, number, or `Unknown(N)` form) to a friendly
+/// client name. Falls back to the trimmed raw value, or `"unknown"` when absent.
+pub fn resolve_client_name(raw: Option<&str>) -> String {
+    match raw.map(str::trim).filter(|value| !value.is_empty()) {
+        None => "unknown".to_string(),
+        Some(raw) => resolve_known_client(raw)
+            .map(|(_, name)| name.to_string())
+            .unwrap_or_else(|| raw.to_string()),
+    }
+}
+
+fn resolve_known_client(raw: &str) -> Option<(u16, &'static str)> {
+    if let Some(code) = parse_client_code(raw) {
+        return KNOWN_CLIENTS
+            .iter()
+            .copied()
+            .find(|(known_code, _)| *known_code == code);
+    }
+
+    let normalized = normalize_name(raw);
+    KNOWN_CLIENTS
+        .iter()
+        .copied()
+        .find(|(_, name)| normalize_name(name) == normalized)
+}
+
+/// Parses a numeric client id. Accepts plain integers (the legacy wire format)
+/// and the `Unknown(N)` form emitted by the node's `ClientId` display.
+fn parse_client_code(raw: &str) -> Option<u16> {
+    if let Ok(code) = raw.parse::<u16>() {
+        return Some(code);
+    }
+    let inner = raw.strip_prefix("Unknown(")?.strip_suffix(')')?;
+    inner.trim().parse::<u16>().ok()
+}
+
+/// Normalizes a client name for tolerant matching: lowercase and drop any
+/// non-alphanumeric characters so "Solana Labs", "SolanaLabs" and "solanalabs"
+/// all resolve to the same client.
+fn normalize_name(value: &str) -> String {
+    value
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_client_name;
+
+    #[test]
+    fn resolves_by_name() {
+        assert_eq!(resolve_client_name(Some("Firedancer")), "Firedancer");
+    }
+
+    #[test]
+    fn resolves_ignoring_spaces_and_case() {
+        assert_eq!(resolve_client_name(Some("Solana Labs")), "SolanaLabs");
+        assert_eq!(resolve_client_name(Some("agave bam")), "AgaveBam");
+    }
+
+    #[test]
+    fn resolves_new_clients() {
+        assert_eq!(resolve_client_name(Some("FireBAM")), "FireBAM");
+        assert_eq!(resolve_client_name(Some("Raiku")), "Raiku");
+    }
+
+    #[test]
+    fn resolves_numeric_and_unknown_forms() {
+        assert_eq!(resolve_client_name(Some("5")), "Firedancer");
+        assert_eq!(resolve_client_name(Some("Unknown(13)")), "Raiku");
+    }
+
+    #[test]
+    fn keeps_unresolved_raw() {
+        assert_eq!(resolve_client_name(Some("Mango")), "Mango");
+    }
+
+    #[test]
+    fn empty_is_unknown() {
+        assert_eq!(resolve_client_name(Some("  ")), "unknown");
+        assert_eq!(resolve_client_name(None), "unknown");
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,8 +24,6 @@ pub struct ExporterConfig {
     pub vote_account_whitelist: Option<Whitelist>,
     /// Whitelisted staking account pubkeys for APY calculation
     pub staking_account_whitelist: Option<Whitelist>,
-    /// Maxmind API username and password.
-    pub maxmind: Option<MaxMindAPIKey>,
     /// Whjether to process rewards data or not
     pub enable_rewards: Option<bool>,
     /// Whjether to process skipped slots data or not
@@ -35,4 +33,21 @@ pub struct ExporterConfig {
     /// by the vote-account whitelist, so it adds one series per network node
     /// (thousands). Defaults to `false`.
     pub enable_gossip_node_info: Option<bool>,
+    /// Whether to export the cluster-wide `solana_validator_node_info` enrichment
+    /// metric (identity -> vote account, version, client, country, ASN, DZ edge)
+    /// and `solana_validator_node_stake`. Covers every cluster node (thousands) and
+    /// enables the ip-api geolocation background task. Defaults to `false`.
+    pub enable_validator_node_info: Option<bool>,
+    /// ip-api base URL used for enrichment geolocation. Defaults to the free tier
+    /// endpoint (`http://ip-api.com`).
+    pub ip_api_base_url: Option<String>,
+    /// Whether to resolve DoubleZero edge membership for the `dz_edge` label on
+    /// `solana_validator_node_info`. Adds egress to the DZ publisher endpoint.
+    /// Defaults to `false`.
+    pub enable_dz_edge: Option<bool>,
+    /// DoubleZero publisher-check endpoint used when `enable_dz_edge` is set.
+    pub dz_publisher_url: Option<String>,
+    /// Maxmind API username and password. Serialized last: it is a TOML table
+    /// (`[maxmind]`) and TOML requires all scalar values before any table.
+    pub maxmind: Option<MaxMindAPIKey>,
 }

--- a/src/enrichment.rs
+++ b/src/enrichment.rs
@@ -1,0 +1,427 @@
+//! Offloaded leader-enrichment sources for the joinable `solana_validator_node_info`
+//! metric: ip-api geolocation (country + ASN) and DoubleZero edge membership.
+//!
+//! Both are refreshed by a single background task so the per-cycle metric publish
+//! never blocks on an external API. The caches are sticky: a transient API failure
+//! leaves the last-known value in place rather than downgrading it to "unknown"
+//! (which would churn Prometheus series). An IP is only reported as unknown until
+//! its first successful lookup, then retried on the next tick.
+
+use anyhow::Context;
+use log::{debug, warn};
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+/// Default ip-api base URL (free tier, HTTP-only).
+pub const DEFAULT_IP_API_BASE_URL: &str = "http://ip-api.com";
+/// Default DoubleZero publisher-check endpoint.
+pub const DEFAULT_DZ_PUBLISHER_URL: &str = "https://data.malbeclabs.com/api/dz/publisher-check";
+/// ip-api batches accept at most 100 queries per request.
+const IP_API_BATCH_SIZE: usize = 100;
+/// Spacing between batch requests: one per 1.5s caps the rate at ~40/min, under
+/// the free tier's ~45/min limit while continuously draining the backlog.
+const IP_API_BATCH_SPACING: Duration = Duration::from_millis(1500);
+/// Idle poll interval once every wanted IP is resolved or backing off. Short so
+/// the initial drain starts promptly after the main loop publishes its first
+/// target set; each idle poll is just an in-memory read.
+const IDLE_INTERVAL: Duration = Duration::from_secs(5);
+/// Backoff after a whole-batch failure (network error / rate limit) before
+/// retrying, so an ip-api outage does not spin.
+const ERROR_BACKOFF: Duration = Duration::from_secs(10);
+/// How long to wait before re-querying an IP whose lookup returned no location
+/// (e.g. a private or unlocatable address), so we do not burn the rate budget
+/// retrying permanent failures every pass.
+const NEGATIVE_BACKOFF: Duration = Duration::from_secs(30 * 60);
+
+/// Parses the bare IP out of an optional `ip:port` (or bracketed IPv6) string.
+pub fn socket_ip(addr: &Option<String>) -> Option<IpAddr> {
+    let value = addr.as_deref()?;
+    if let Ok(socket) = value.parse::<SocketAddr>() {
+        return Some(socket.ip());
+    }
+    value
+        .rsplit_once(':')
+        .map(|(host, _)| host)
+        .unwrap_or(value)
+        .trim_matches(|c| c == '[' || c == ']')
+        .parse()
+        .ok()
+}
+
+/// Geolocation for a single IP. `country_code` present means "resolved".
+#[derive(Clone, Debug, Default)]
+pub struct IpGeo {
+    pub country_code: Option<String>,
+    pub asn: Option<u32>,
+}
+
+/// Cache entry: a resolved geo (`country_code.is_some()`) is sticky forever; an
+/// unresolved entry carries the time after which it may be retried.
+#[derive(Clone, Default)]
+struct GeoEntry {
+    geo: IpGeo,
+    retry_after: Option<Instant>,
+}
+
+/// Sticky in-memory IP -> geolocation cache shared between the background
+/// refresh task and the metric-publish path.
+#[derive(Clone, Default)]
+pub struct IpGeoCache {
+    inner: Arc<RwLock<HashMap<IpAddr, GeoEntry>>>,
+}
+
+impl IpGeoCache {
+    /// Resolved geolocation for `ip`, or `None` while unknown.
+    pub fn get(&self, ip: &IpAddr) -> Option<IpGeo> {
+        let map = self.inner.read().ok()?;
+        let entry = map.get(ip)?;
+        entry.geo.country_code.as_ref().map(|_| entry.geo.clone())
+    }
+
+    /// Global IPs that still need a lookup: never queried, or a prior failure
+    /// whose backoff has elapsed. Non-global (private/loopback) IPs are skipped
+    /// entirely since ip-api cannot locate them.
+    fn due_for_lookup(&self, ips: &[IpAddr]) -> Vec<IpAddr> {
+        let now = Instant::now();
+        let guard = self.inner.read();
+        ips.iter()
+            .copied()
+            .filter(is_global)
+            .filter(|ip| match guard.as_ref().ok().and_then(|map| map.get(ip)) {
+                None => true,
+                Some(entry) => {
+                    entry.geo.country_code.is_none()
+                        && entry.retry_after.map(|at| at <= now).unwrap_or(true)
+                }
+            })
+            .collect()
+    }
+
+    /// Records freshly resolved locations (sticky).
+    fn mark_resolved(&self, records: impl IntoIterator<Item = (IpAddr, IpGeo)>) {
+        if let Ok(mut map) = self.inner.write() {
+            for (ip, geo) in records {
+                map.insert(
+                    ip,
+                    GeoEntry {
+                        geo,
+                        retry_after: None,
+                    },
+                );
+            }
+        }
+    }
+
+    /// Records a lookup that returned no location, scheduling a retry after the
+    /// negative backoff. Never clobbers an already-resolved entry.
+    fn mark_failed(&self, ips: impl IntoIterator<Item = IpAddr>) {
+        let retry_after = Some(Instant::now() + NEGATIVE_BACKOFF);
+        if let Ok(mut map) = self.inner.write() {
+            for ip in ips {
+                let entry = map.entry(ip).or_default();
+                if entry.geo.country_code.is_none() {
+                    entry.retry_after = retry_after;
+                }
+            }
+        }
+    }
+}
+
+/// Whether an IP is globally routable enough to bother geolocating. Skips
+/// loopback, private, link-local, broadcast, documentation and unspecified
+/// ranges (e.g. our own WireGuard gossip addresses).
+fn is_global(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            !(v4.is_private()
+                || v4.is_loopback()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_documentation()
+                || v4.is_unspecified())
+        }
+        IpAddr::V6(v6) => !(v6.is_loopback() || v6.is_unspecified()),
+    }
+}
+
+/// DoubleZero edge publishers for the current epoch. `None` means never fetched.
+#[derive(Clone, Default)]
+pub struct DzEdgeCache {
+    inner: Arc<RwLock<Option<DzEdgeState>>>,
+}
+
+struct DzEdgeState {
+    epoch: u64,
+    edges: HashSet<String>,
+}
+
+impl DzEdgeCache {
+    /// `Some(true|false)` once fetched, `None` while unknown.
+    pub fn is_edge(&self, node_pubkey: &str) -> Option<bool> {
+        let guard = self.inner.read().ok()?;
+        let state = guard.as_ref()?;
+        Some(state.edges.contains(node_pubkey))
+    }
+
+    fn cached_epoch(&self) -> Option<u64> {
+        self.inner
+            .read()
+            .ok()
+            .and_then(|guard| guard.as_ref().map(|state| state.epoch))
+    }
+
+    fn install(&self, epoch: u64, edges: HashSet<String>) {
+        if let Ok(mut guard) = self.inner.write() {
+            *guard = Some(DzEdgeState { epoch, edges });
+        }
+    }
+}
+
+/// Shared handles the main loop uses to feed the background task and read the
+/// enrichment caches when publishing metrics.
+#[derive(Clone)]
+pub struct Enrichment {
+    pub geo: IpGeoCache,
+    pub dz: DzEdgeCache,
+    wanted_ips: Arc<RwLock<Vec<IpAddr>>>,
+    current_epoch: Arc<AtomicU64>,
+}
+
+impl Enrichment {
+    pub fn new() -> Self {
+        Self {
+            geo: IpGeoCache::default(),
+            dz: DzEdgeCache::default(),
+            wanted_ips: Arc::new(RwLock::new(Vec::new())),
+            current_epoch: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Publishes the current cluster gossip IPs and epoch for the background task
+    /// to work from. Called once per cycle from the main loop.
+    pub fn set_targets(&self, ips: Vec<IpAddr>, epoch: u64) {
+        if let Ok(mut guard) = self.wanted_ips.write() {
+            *guard = ips;
+        }
+        self.current_epoch.store(epoch, Ordering::Relaxed);
+    }
+
+    /// Spawns the background refresh task. `dz_url` = `None` disables DZ edge.
+    pub fn spawn_task(&self, ip_api_base_url: String, dz_url: Option<String>) {
+        let geo = self.geo.clone();
+        let dz = self.dz.clone();
+        let wanted_ips = Arc::clone(&self.wanted_ips);
+        let current_epoch = Arc::clone(&self.current_epoch);
+        let ip_api = IpApiClient::new(reqwest::Client::new(), ip_api_base_url);
+        let dz_client = reqwest::Client::new();
+
+        // Continuous, self-pacing drain: one ip-api batch per tick (~40/min),
+        // idling when everything is resolved or backing off. DZ edge is refreshed
+        // opportunistically each pass (a cheap per-epoch gate).
+        tokio::spawn(async move {
+            loop {
+                if let Some(url) = dz_url.as_deref() {
+                    refresh_dz(&dz_client, &dz, &current_epoch, url).await;
+                }
+
+                let ips = wanted_ips
+                    .read()
+                    .map(|guard| guard.clone())
+                    .unwrap_or_default();
+                let mut due = geo.due_for_lookup(&ips);
+                if due.is_empty() {
+                    tokio::time::sleep(IDLE_INTERVAL).await;
+                    continue;
+                }
+
+                due.truncate(IP_API_BATCH_SIZE);
+                match ip_api.lookup_batch(&due).await {
+                    Ok(found) => {
+                        let resolved: HashSet<IpAddr> = found.iter().map(|(ip, _)| *ip).collect();
+                        let failed = due.iter().copied().filter(|ip| !resolved.contains(ip));
+                        geo.mark_failed(failed);
+                        geo.mark_resolved(found);
+                        tokio::time::sleep(IP_API_BATCH_SPACING).await;
+                    }
+                    Err(error) => {
+                        // Whole-batch failure (network / rate limit): keep last-known
+                        // and back off without penalizing the individual IPs.
+                        warn!("ip-api batch failed: {error:#}");
+                        tokio::time::sleep(ERROR_BACKOFF).await;
+                    }
+                }
+            }
+        });
+    }
+}
+
+impl Default for Enrichment {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+async fn refresh_dz(
+    client: &reqwest::Client,
+    dz: &DzEdgeCache,
+    current_epoch: &Arc<AtomicU64>,
+    url: &str,
+) {
+    let epoch = current_epoch.load(Ordering::Relaxed);
+    // epoch 0 = the main loop has not published one yet; skip until it has.
+    if epoch == 0 || dz.cached_epoch() == Some(epoch) {
+        return;
+    }
+    match fetch_dz_edges(client, url).await {
+        Ok(edges) => {
+            debug!("DZ edge: {} publisher(s) @ epoch {}", edges.len(), epoch);
+            dz.install(epoch, edges);
+        }
+        Err(error) => warn!("DZ edge refresh failed: {error:#}"),
+    }
+}
+
+struct IpApiClient {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+#[derive(Deserialize)]
+struct IpApiRecord {
+    status: String,
+    #[serde(rename = "countryCode")]
+    country_code: Option<String>,
+    query: Option<String>,
+    #[serde(rename = "as")]
+    as_name: Option<String>,
+}
+
+impl IpApiClient {
+    fn new(client: reqwest::Client, base_url: String) -> Self {
+        Self { client, base_url }
+    }
+
+    async fn lookup_batch(&self, ips: &[IpAddr]) -> anyhow::Result<Vec<(IpAddr, IpGeo)>> {
+        if ips.is_empty() {
+            return Ok(Vec::new());
+        }
+        let url = format!(
+            "{}/batch?fields=status,countryCode,query,as",
+            self.base_url.trim_end_matches('/')
+        );
+        let body: Vec<_> = ips
+            .iter()
+            .map(|ip| serde_json::json!({ "query": ip.to_string() }))
+            .collect();
+
+        let response = self
+            .client
+            .post(url)
+            .json(&body)
+            .send()
+            .await
+            .context("ip-api batch request failed")?;
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            anyhow::bail!("ip-api batch returned HTTP {status}: {text}");
+        }
+        let records: Vec<IpApiRecord> = response
+            .json()
+            .await
+            .context("failed to decode ip-api batch response")?;
+        Ok(records.into_iter().filter_map(record_to_geo).collect())
+    }
+}
+
+fn record_to_geo(record: IpApiRecord) -> Option<(IpAddr, IpGeo)> {
+    if record.status != "success" {
+        return None;
+    }
+    let ip: IpAddr = record.query?.parse().ok()?;
+    let country_code = record
+        .country_code
+        .filter(|code| !code.trim().is_empty())
+        .map(|code| code.to_ascii_uppercase())?;
+    let asn = record.as_name.as_deref().and_then(parse_asn);
+    Some((
+        ip,
+        IpGeo {
+            country_code: Some(country_code),
+            asn,
+        },
+    ))
+}
+
+/// Extracts the ASN number (e.g. 16509) from an ip-api `as` string like
+/// "AS16509 Amazon.com, Inc.".
+fn parse_asn(as_name: &str) -> Option<u32> {
+    let trimmed = as_name.trim();
+    let stripped = trimmed.strip_prefix("AS").unwrap_or(trimmed);
+    let head: String = stripped.chars().take_while(|c| c.is_ascii_digit()).collect();
+    head.parse().ok()
+}
+
+#[derive(Deserialize)]
+struct DzResponse {
+    publishers: Vec<DzPublisher>,
+}
+
+#[derive(Deserialize)]
+struct DzPublisher {
+    node_pubkey: String,
+    #[serde(default)]
+    publishing_leader_shreds: bool,
+}
+
+async fn fetch_dz_edges(client: &reqwest::Client, url: &str) -> anyhow::Result<HashSet<String>> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .context("DZ publisher request failed")?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        anyhow::bail!("DZ publisher returned HTTP {status}: {text}");
+    }
+    let parsed: DzResponse = response
+        .json()
+        .await
+        .context("failed to decode DZ publisher response")?;
+    Ok(parsed
+        .publishers
+        .into_iter()
+        .filter(|publisher| publisher.publishing_leader_shreds)
+        .map(|publisher| publisher.node_pubkey)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_asn, socket_ip};
+
+    #[test]
+    fn parses_asn() {
+        assert_eq!(parse_asn("AS16509 Amazon.com, Inc."), Some(16509));
+        assert_eq!(parse_asn("16509"), Some(16509));
+        assert_eq!(parse_asn("Amazon"), None);
+    }
+
+    #[test]
+    fn parses_socket_ip() {
+        assert_eq!(
+            socket_ip(&Some("64.130.42.197:8002".to_string())).map(|ip| ip.to_string()),
+            Some("64.130.42.197".to_string())
+        );
+        assert_eq!(
+            socket_ip(&Some("[2001:db8::1]:8001".to_string())).map(|ip| ip.to_string()),
+            Some("2001:db8::1".to_string())
+        );
+        assert_eq!(socket_ip(&None), None);
+    }
+}

--- a/src/gauges.rs
+++ b/src/gauges.rs
@@ -1,4 +1,6 @@
+use crate::client_id::resolve_client_name;
 use crate::config::Whitelist;
+use crate::enrichment::{socket_ip, DzEdgeCache, IpGeoCache};
 use crate::geolocation::api::MaxMindAPIKey;
 use crate::geolocation::api::MAXMIND_CITY_URI;
 use crate::geolocation::caching::GeolocationCache;
@@ -79,6 +81,8 @@ pub struct PrometheusGauges {
     pub nodes: IntGauge,
     pub average_slot_time: Gauge,
     pub gossip_node_info: IntGaugeVec,
+    pub validator_node_info: IntGaugeVec,
+    pub validator_node_stake: IntGaugeVec,
     // Connection pool for querying
     client: reqwest::Client,
     vote_accounts_whitelist: Whitelist,
@@ -238,6 +242,29 @@ impl PrometheusGauges {
                     "tpu_ip",
                     "version",
                 ]
+            )
+            .unwrap(),
+            validator_node_info: register_int_gauge_vec!(
+                "solana_validator_node_info",
+                "Cluster-wide validator enrichment: one series per cluster node keyed \
+                 by identity, carrying vote account, version, client, country, ASN and \
+                 DoubleZero edge membership for dashboard joins. Value is always 1.",
+                &[
+                    IDENTITY_LABEL,
+                    "vote_key",
+                    "version",
+                    "client",
+                    "country_code",
+                    "asn",
+                    "dz_edge",
+                ]
+            )
+            .unwrap(),
+            validator_node_stake: register_int_gauge_vec!(
+                "solana_validator_node_stake",
+                "Activated stake in lamports keyed by node identity (all validators), \
+                 for joining stake onto identity-keyed metrics.",
+                &[IDENTITY_LABEL]
             )
             .unwrap(),
             client: reqwest::Client::new(),
@@ -463,6 +490,74 @@ impl PrometheusGauges {
                     version,
                 ])
                 .map(|m| m.set(1))?;
+        }
+
+        Ok(())
+    }
+
+    /// Exports the cluster-wide `solana_validator_node_info` enrichment metric
+    /// (one series per node, keyed by identity) plus `solana_validator_node_stake`
+    /// (per-identity activated stake). Geolocation and DZ edge membership are read
+    /// from the sticky caches populated out-of-band by the enrichment task, so this
+    /// never blocks on an external API. Both gauges are reset each cycle so departed
+    /// nodes do not linger.
+    pub fn export_validator_node_info(
+        &self,
+        nodes: &[GossipNode],
+        vote_accounts: &RpcVoteAccountStatus,
+        geo: &IpGeoCache,
+        dz: &DzEdgeCache,
+    ) -> anyhow::Result<()> {
+        // node identity -> (vote account, activated stake). Non-voting nodes absent.
+        let vote_by_node: HashMap<&str, (&str, u64)> = vote_accounts
+            .current
+            .iter()
+            .chain(vote_accounts.delinquent.iter())
+            .map(|v| (v.node_pubkey.as_str(), (v.vote_pubkey.as_str(), v.activated_stake)))
+            .collect();
+
+        self.validator_node_info.reset();
+        self.validator_node_stake.reset();
+
+        for node in nodes {
+            let vote_stake = vote_by_node.get(node.pubkey.as_str()).copied();
+            let (vote_account, stake) = vote_stake.unwrap_or(("", 0));
+            let version = node.version.as_deref().unwrap_or("unknown");
+            let client = resolve_client_name(node.client_id.as_deref());
+            let (country_code, asn) = socket_ip(&node.gossip)
+                .and_then(|ip| geo.get(&ip))
+                .map(|geo| {
+                    (
+                        geo.country_code.unwrap_or_else(|| "unknown".to_string()),
+                        geo.asn
+                            .map(|asn| asn.to_string())
+                            .unwrap_or_else(|| "unknown".to_string()),
+                    )
+                })
+                .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
+            let dz_edge = match dz.is_edge(&node.pubkey) {
+                Some(true) => "true",
+                Some(false) => "false",
+                None => "unknown",
+            };
+
+            self.validator_node_info
+                .get_metric_with_label_values(&[
+                    &node.pubkey,
+                    vote_account,
+                    version,
+                    &client,
+                    &country_code,
+                    &asn,
+                    dz_edge,
+                ])
+                .map(|m| m.set(1))?;
+
+            if vote_stake.is_some() {
+                self.validator_node_stake
+                    .get_metric_with_label_values(&[&node.pubkey])
+                    .map(|m| m.set(stake as i64))?;
+            }
         }
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,9 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::{fs, time::Duration};
 
+pub mod client_id;
 pub mod config;
+pub mod enrichment;
 pub mod gauges;
 pub mod geolocation;
 pub mod persistent_database;
@@ -69,6 +71,10 @@ async fn main() -> anyhow::Result<()> {
             enable_rewards: Some(true),
             enable_skipped_slots: Some(true),
             enable_gossip_node_info: Some(false),
+            enable_validator_node_info: Some(false),
+            ip_api_base_url: Some(enrichment::DEFAULT_IP_API_BASE_URL.to_string()),
+            enable_dz_edge: Some(false),
+            dz_publisher_url: Some(enrichment::DEFAULT_DZ_PUBLISHER_URL.to_string()),
         };
 
         let location = sc
@@ -155,8 +161,31 @@ and then put real values there.",
     let enable_rewards = config.enable_rewards.unwrap_or(true);
     let enable_skipped_slots = config.enable_skipped_slots.unwrap_or(true);
     let enable_gossip_node_info = config.enable_gossip_node_info.unwrap_or(false);
+    let enable_validator_node_info = config.enable_validator_node_info.unwrap_or(false);
 
     let gauges = PrometheusGauges::new(vote_accounts_whitelist.clone());
+
+    // Offloaded leader enrichment (ip-api geolocation + DZ edge). The background
+    // task keeps the sticky caches fresh so the per-cycle publish never blocks on
+    // an external API.
+    let enrichment = enrichment::Enrichment::new();
+    if enable_validator_node_info {
+        let ip_api_base_url = config
+            .ip_api_base_url
+            .clone()
+            .unwrap_or_else(|| enrichment::DEFAULT_IP_API_BASE_URL.to_string());
+        let dz_url = if config.enable_dz_edge.unwrap_or(false) {
+            Some(
+                config
+                    .dz_publisher_url
+                    .clone()
+                    .unwrap_or_else(|| enrichment::DEFAULT_DZ_PUBLISHER_URL.to_string()),
+            )
+        } else {
+            None
+        };
+        enrichment.spawn_task(ip_api_base_url, dz_url);
+    }
     let mut skipped_slots_monitor = if enable_skipped_slots {
         Some(SkippedSlotsMonitor::new(
             &client,
@@ -229,10 +258,29 @@ and then put real values there.",
         {
             warn!("Failed to export node info metrics: {e:#}");
         }
-        if enable_gossip_node_info {
+        if enable_gossip_node_info || enable_validator_node_info {
             let gossip_nodes = rpc_extra::parse_gossip_nodes(&raw_nodes);
-            if let Err(e) = gauges.export_gossip_node_info(&gossip_nodes, &vote_accounts) {
-                warn!("Failed to export gossip node info metrics: {e:#}");
+            if enable_gossip_node_info {
+                if let Err(e) = gauges.export_gossip_node_info(&gossip_nodes, &vote_accounts) {
+                    warn!("Failed to export gossip node info metrics: {e:#}");
+                }
+            }
+            if enable_validator_node_info {
+                // Feed the background enrichment task the current gossip IPs/epoch,
+                // then publish from the (last-known) sticky caches.
+                let ips = gossip_nodes
+                    .iter()
+                    .filter_map(|node| enrichment::socket_ip(&node.gossip))
+                    .collect();
+                enrichment.set_targets(ips, epoch_info.epoch);
+                if let Err(e) = gauges.export_validator_node_info(
+                    &gossip_nodes,
+                    &vote_accounts,
+                    &enrichment.geo,
+                    &enrichment.dz,
+                ) {
+                    warn!("Failed to export validator node info metrics: {e:#}");
+                }
             }
         }
         if let Some(maxmind) = config.maxmind.clone() {

--- a/src/rpc_extra.rs
+++ b/src/rpc_extra.rs
@@ -25,6 +25,10 @@ pub struct GossipNode {
     pub tpu: Option<String>,
     /// Software version, if advertised.
     pub version: Option<String>,
+    /// Client id, if advertised (string name or number; see
+    /// [`get_cluster_nodes_raw`], which coerces it to a string).
+    #[serde(default)]
+    pub client_id: Option<String>,
 }
 
 /// Parses an already-fetched `getClusterNodes` JSON payload (as returned by


### PR DESCRIPTION
Adds an identity-keyed metric so dashboards can join validator metadata
(location, client, version, DoubleZero edge, stake) onto other metrics,
instead of each tool polling getClusterNodes, getVoteAccounts and a geo API
on its own.

New metrics:
- solana_validator_node_info{identity, vote_key, version, client, country_code, asn, dz_edge}: one series per cluster node, reset each cycle.
- solana_validator_node_stake{identity}: activated stake in lamports.

client is resolved from clientId (codes 0-13, or the name, or Unknown(N)).
country_code and asn come from ip-api, dz_edge from the DoubleZero
publisher-check API. A background task fetches both, keeps the last good
value on failure, backs off, skips private IPs and stays under the ip-api
rate limit, so a scrape never blocks on an external call. All of it is off
by default behind config flags.

Also fixes the generate subcommand, which wrote the [maxmind] table before
the scalar values, and updates the stale cli version.

Tested against a mainnet RPC with the feature on: 4366 node_info series,
717 stake series, clients and geolocation resolved, dz_edge populated.
Build, tests and clippy are clean. Version 0.4.2 to 0.5.0, additive only.
